### PR TITLE
DBWrap: Force SQL_MODE=''

### DIFF
--- a/php/inc/database.php
+++ b/php/inc/database.php
@@ -70,6 +70,7 @@ class DBWrap {
     if (!$this->mysqli->set_charset("utf8"))
         throw new InternalException('Unable to select charset utf8. Current character set: ' 
                                     . $mysqli->character_set_name());
+    $this->mysqli->query("SET SESSION SQL_MODE = '';");
   }
   /**
    * The DBWrap class is implemented as a Singleton. Call this


### PR DESCRIPTION
Force `SQL_MODE=''` since there are pages that fails if `'STRICT_TRANS_TABLES'` is used.

eg `manage providers.php` fails when:
- creates a new provider without "Processing time":
  `error 1366: Incorrect integer value: '' for column 'offset_order_close'`
- goes to list products of a provider:
  `error 1292: Incorrect date value: '0'` at `CALL get products_detail`
