### PR TITLE
Import data of a table without foreign keys show a error.

### DIFF
--- a/php/lib/abstract_import_manager.php
+++ b/php/lib/abstract_import_manager.php
@@ -390,6 +390,7 @@ class abstract_import_manager {
     private function _build_foreign_key_cache($key_array){
     	$db = DBWrap::get_instance();
     	
+    	$this->_foreign_keys = array();
     	foreach ($key_array as $db_field=>$refs){
     		if (isset($refs) && count($refs) > 1){
 	    		$sql = "select ". $refs[1]." from " . $refs[0];


### PR DESCRIPTION
The error occurs when calling the function `_foreign_key_exists` of the class `abstract_import_manager`

It is an unlikely problem, but occurs if the tables are created without FK (incorrect installation, of course!)
Also will occur if in the future on a new code to import an other table without FK.
