### PR TITLE
The XML can be cut in the last three characters.

### DIFF
--- a/php/utilities/general.php
+++ b/php/utilities/general.php
@@ -450,7 +450,7 @@ function query_XML_noparam($queryname)
 
 function printXML($str) {
   $newstr = '<?xml version="1.0" encoding="utf-8"?>';  
-  $newstr .= $str; 
+  $newstr .= $str.'   ';
   header('Content-Type: text/xml');
   header('Last-Modified: '.date(DATE_RFC822));
   header('Pragma: no-cache');


### PR DESCRIPTION
Using PHP on Apache2 if a XML response is longer that 8000 chars the 3 last chars are cut. This is produced on printXML method of `utilities/general.php`.

Seems that the problem is due to this PHP bug:
  https://bugs.php.net/bug.php?id=45945
Also comented on:
  http://stackoverflow.com/questions/22121282/php-inserts-hex-number-of

The proposed patch adds three spaces to the bug *will eat* them if present.