### PR TITLE
dev3.0: Wrong url on message foot if Aixada is the root forlder.

### DIFF
--- a/php/lib/deliver_email.php
+++ b/php/lib/deliver_email.php
@@ -47,7 +47,7 @@ class Deliver_email extends Deliver {
 
 		// get URL of aixada root
 		$pos_root = strrpos($_SERVER['SCRIPT_NAME'], '/php/ctrl/');
-		if (!$pos_root) {
+		if ($pos_root === false) {
 			$pos_root = strrpos($_SERVER['SCRIPT_NAME'], '/');
 		}
 


### PR DESCRIPTION
Patch to `dev3.0` from ``master` #111