### PR TITLE
Total VAT must be with rev_tax applied, otherwise total

### DIFF
--- a/js/aixadacart/jquery.aixadacart.js
+++ b/js/aixadacart/jquery.aixadacart.js
@@ -584,8 +584,8 @@
   			        var item_net = item_total / (1 + rev_tax/100) / (1 + iva_tax/100);
 				
 				//iva and revtax is contained in the unit_price
-				iva_tax_total += item_net * (iva_tax/100);
 				rev_tax_total += item_net * (rev_tax/100);
+				iva_tax_total += item_net * (1+(rev_tax/100)) * (iva_tax/100);
 	
 				total_net += item_net;
 				


### PR DESCRIPTION
Total VAT must be with rev_tax applied:

Otherwise when rev_tax and IVA are not zero `total` is not equal to `total_net + rev_tax_total + iva_tax_total`