### PR TITLE
The XML can be cut in the last three characters.

### DIFF
--- a/php/utilities/general.php
+++ b/php/utilities/general.php
@@ -558,7 +558,7 @@ function query_XML_noparam($queryname)
 
 function printXML($str) {
   $newstr = '<?xml version="1.0" encoding="utf-8"?>';  
-  $newstr .= $str; 
+  $newstr .= $str.'      ';
   header('Content-Type: text/xml');
   header('Last-Modified: '.date(DATE_RFC822));
   header('Pragma: no-cache');

--- a/php/utilities/general.php
+++ b/php/utilities/general.php
@@ -558,13 +558,13 @@ function query_XML_noparam($queryname)
 
 function printXML($str) {
   $newstr = '<?xml version="1.0" encoding="utf-8"?>';  
-  $newstr .= $str.'      ';
+  $newstr .= $str;
   header('Content-Type: text/xml');
   header('Last-Modified: '.date(DATE_RFC822));
   header('Pragma: no-cache');
   header('Cache-Control: no-cache, must-revalidate');
   header('Expires: '. date(DATE_RFC822, time() - 3600));
-  header('Content-Length: ' . strlen($newstr));
+  // header('Content-Length: ' . strlen($newstr)); // See comments of on #134
   echo $newstr;
 }
 


### PR DESCRIPTION
Using PHP on Apache2 if a XML response is longer that 8000 chars 3 or 6 last chars are cut. This is produced on printXML method of `utilities/general.php`.

Seems that the problem is due to this PHP bug:
  https://bugs.php.net/bug.php?id=45945
Also comented on:
  http://stackoverflow.com/questions/22121282/php-inserts-hex-number-of

NOTE: Unfortunately I was unable to determine whether possible to lose more characters, but those tests
 I made this patch allows working with Aixada without this problem.