### PR TITLE
Able to use align on th/td on table.tblListingDefault

### DIFF
--- a/css/aixada_main.css
+++ b/css/aixada_main.css
@@ -78,7 +78,11 @@ option 				{padding:1px 5px;}
 /** different table styles **/
 table.tblListingDefault				{width:100%;  border-collapse:collapse;}
 table.tblListingDefault th			{background:#f3f3f3; padding:4px 2px; text-align:left;}
+table.tblListingDefault th.textAlignRight { text-align: right; }
+table.tblListingDefault th.textAlignCenter { text-align: center; }
 table.tblListingDefault td			{padding:2px 8px; text-align:left; vertical-align:bottom;}
+table.tblListingDefault td.textAlignRight { text-align: right; }
+table.tblListingDefault td.textAlignCenter { text-align: center; }
 table.tblListingDefault tfoot td	{padding:2px 4px; margin:1px; text-align:right;}
 
 table.tblListingGrid			{width:100%;}


### PR DESCRIPTION
This change allow to use classes `textAlignRight` & `textAlignCenter` on `<th>` and `<td>` elements without a sub-element as `<p>`.
So allows for a less overhead html code.

This affects some existing presentations that had not been taken into account that alignment was forced to the left on `table.tblListingDefault th/td`. Especially in some titles e.g. "*Balace*" on `validate.php`