### PR TITLE
ui-state-error: Ensure contrasts in all styles

### DIFF
--- a/css/aixada_main.css
+++ b/css/aixada_main.css
@@ -204,7 +204,8 @@ p#logonHeader			{width:100%; height:150px; margin:10px auto; background-color:#f
 .ui-state-error, div.ui-widget .ui-state-error,
 .success_tips			{text-align:center; border-radius:10px;}
 .ui-state-error, div.ui-widget .ui-state-error
-						{background-color: #fdd; background-image: none;}
+						{background-color: #fdd; background-image: none;
+						color:#933;}
 sup						{color:red; font-size:0.6em; padding-top:3px;}
 
 div.portalPost			{border-bottom:3px solid #e4e4f1;}


### PR DESCRIPTION
The style `ui-lightness` shows errors blank. After #138, to have a good contrasts suggested changing the color (to give a good contrasts in relation to the `background-color:#fdd`)