### PR TITLE
Use the UTF-8 without BOM.

### DIFF
--- a/php/utilities/useruf.php
+++ b/php/utilities/useruf.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 
 require_once(__ROOT__ . 'php/inc/database.php');


### PR DESCRIPTION
Using UTF-8 (with BOM) can cause loss of the last 3 characters in the ajax XML requests, (or additional 3 (3 + 3 = 6) as described in PR #134)
Yet BOM seems that is not the only reason, in my tests it is clear that this is one of the reasons.

Justification note: In my current development server on `UserAndUf.php?oper=getMemberListing&all=1` only lose 3 chararters but on my old server (it broke) 6 characters were lost using this control and the others controls 3 characters were lost. Currently this is the only control who fails me. And removing BOM everything works.