### PR TITLE
Allow to review an order distributed without losing the previous review done.

### DIFF
--- a/css/aixada_main.css
+++ b/css/aixada_main.css
@@ -334,6 +334,7 @@ td.missing	{background:#FFCCCA;}
 .editHighlightRow			{opacity:.6}
 .editHighlightCol			{opacity:.6}
 
+.isSend			{background:#e8e8e8;}
 .asOrdered		{background:#D1F3D1;}
 .withChanges	{background:#FFEDA1;}
 .orderCanceled	{background:#ff7a75;}

--- a/local_config/lang/ca-va.php
+++ b/local_config/lang/ca-va.php
@@ -691,8 +691,14 @@ $Text['msg_finalize'] = "Estàs a punt de finalitzar la comanda. Si ho fas, ja n
 $Text['msg_finalize_open'] = "Aquesta comanda encara està oberta. Si la finalitzes ara, l'estaràs tancant abans de la seva data límit. Estàs segur de voler continuar?";
 $Text['msg_wait_tbl'] = "L'encapçalament de la taula s'està construint. Això pot trigar una mica en funció de la velocitat del teu navegador. Torna-ho a provar en 5 segons. ";
 $Text['msg_err_invalid_id'] = "No s'ha trobat un ID de la comanda! Aquesta comanda no s'ha enviat al proveïdor!!";
-$Text['msg_revise_revised'] = "Els elements de la comanda ja han estat revisats i carregats a les cistelles dels usuaris per a la data indicada. Tornar-los a revisar alteraria les modificacions ja fetes, i podria interferir amb les modificacions fetes pels propis usuaris. <br/><br/> Estàs segur de voler continuar?! <br/><br/>Si acceptes s'eliminaran els articles de les cistelles, i el procés de revisió començarà de nou.";
+$Text['msg_revise_revised'] = 
+    "Els elements de la comanda ja han estat revisats i carregats a les cistelles dels usuaris.<br>
+    Tornar-los a revisar pot interferir amb modificacions fetes pels propis usuaris.<br><br>
+    Les opcions possibles són o <b>modificar</b> la revisió feta o <b>esborrar</b>-la i començar de nou.";
+$Text['btn_modify'] = "Modificar";
+$Text['btn_delete'] = "Esborrar";
 $Text['wait_reset'] = "Si us plau, espera mentre re-inicialitzo la comanda...";
+$Text['msg_done'] = "Fet!";
 $Text['msg_err_already_val'] = "Alguns dels elements de la comanda ja han estat validats! Em sap greu, però ja no s'hi poden fer modificacions!!";
 $Text['print_several'] = "Hi ha més d'una comanda seleccionada. Vols imprimir-les totes?";
 $Text['btn_yes_all'] = "Sí, imprimeix-les totes";
@@ -741,9 +747,11 @@ $Text['total_orginal_order'] = "Comanda original";
 $Text['total_after_revision'] = "Després de revisió";
 $Text['delivery_ref'] = "Referència d'entrega";
 $Text['payment_ref'] = "Referència de pagament";
-$Text['arrived'] = "arribat"; //as in order items have arrived. this is a table heading
+$Text['arrived'] = "Arribat"; //as in order items have arrived. this is a table heading
+$Text['tit_set_orStatus'] = "Establir l'estat de la comanda";
+$Text['tit_set_shpDate'] = "Establir data de la compra";
 $Text['msg_cur_status'] = "L'estat de la comanda és";
-$Text['msg_change_status'] = "Canvia l'estat de la comanda a un dels següents";
+$Text['msg_change_status'] = "Canvia l'estat a";
 $Text['msg_confirm_move'] = "Estàs segur que vols fer aquesta comanda disponible per a la venda? Tots els productes disponibles es posaran a les cistelles de la data:";
 $Text['alter_date'] = "Tria una data alternativa";
 $Text['msg_err_miss_info'] = "Sembla que aquesta comanda prové d'una versió anterior de la plataforma, incompatible amb la nova funcionalitat de revisió. Em sap greu, però no es pot revisar aquesta comanda.";
@@ -918,6 +926,8 @@ $Text['stock_info_product'] = "Nota: es poden consultar tots els canvis d'estoc 
 
 
 $Text['msg_success'] = "Fi correcte.";
+$Text['msg_confirm'] = "Confirmació";
+$Text['msg_warning'] = "Advertència";
 $Text['msg_confirm_prov'] = "Estàs segur que vols exportar tots els proveïdors?"; 
 $Text['msg_err_upload'] = "S'ha produït un error en la càrrega de l'arxiu "; 
 $Text['msg_import_matchcol'] = "Cal fer coincidir les entrades de la base de dades amb les files de la taula. Has d'assignar la columna que correspon a "; //+ here then comes the name of the matching column, e.g. custom_product_ref

--- a/local_config/lang/en.php
+++ b/local_config/lang/en.php
@@ -698,8 +698,14 @@ $Text['msg_finalize'] = "You are about to finalize an order. This means that no 
 $Text['msg_finalize_open'] = "This order is still open. Finalizing it now implies that you will close it before the announced deadline. Are you sue you want to continue?";
 $Text['msg_wait_tbl'] = "The table header is still being constructed. Depending on your internet connection this might take a little while. Try again in 5 seconds. ";
 $Text['msg_err_invalid_id'] = "No valid ID for order found! This order has not been sent off to the provider!!";
-$Text['msg_revise_revised'] = "The items of this order have already been revised and placed into people\'s carts for the indicated shop date. Revising them again will override the modifications already made and potentially interfere with people\'s own corrections. <br/><br/> Are you really sure you want to proceed anyway?! <br/><br/>Pressing OK will delete the items from the existing shopping carts and start the order-revision process again.";
+$Text['msg_revise_revised'] =
+     "The items of this order have already been revised and placed into people\'s carts.<br>
+     Revising again will override modifications already made and potentially interfere with people\'s own corrections.<br>
+     Possible options are <b>modify</ b> the revision made or <b>delete</ b> it and start again.";
+$Text['btn_modify'] = "Modify";
+$Text['btn_delete'] = "Delete";
 $Text['wait_reset'] = "Please wait while the order is being reset...";
+$Text['msg_done'] = "Done!";
 $Text['msg_err_already_val'] = "Some or all order items have already been validated! Sorry, but it is not possible to make any further changes!!";
 $Text['print_several'] = "There is more than one order currently selected. Do you want to print them all in one go?";
 $Text['btn_yes_all'] = "Yes, print all";
@@ -749,8 +755,10 @@ $Text['total_after_revision'] = "After revision";
 $Text['delivery_ref'] = "Delivery ref.";
 $Text['payment_ref'] = "Payment ref.";
 $Text['arrived'] = "Arrived"; //as in order items have arrived. this is a table heading
+$Text['tit_set_orStatus'] = "Set Order Status";
+$Text['tit_set_shpDate'] = "Set shopping date";
 $Text['msg_cur_status'] = "The current order status is";
-$Text['msg_change_status'] = "Change the order status to one of the following options";
+$Text['msg_change_status'] = "Change the order status to";
 $Text['msg_confirm_move'] = "Are you sure you want to make this order available for shopping? All corresponding products will be placed into the shopping cart for the following date:";
 $Text['alter_date'] = "Choose an alternative date";
 $Text['msg_err_miss_info'] = "It seems that this order was created with an older version of the platform which is incompatible with the current revision functionality. Sorry, but this order cannot be revised.";
@@ -925,6 +933,8 @@ $Text['stock_info_product'] = "Note: consult all previous stock movements (adds,
 
 
 $Text['msg_success'] = "Completed successfully";
+$Text['msg_confirm'] = "Confirm";
+$Text['msg_warning'] = "Warning";
 $Text['msg_confirm_prov'] = "Are you sure you want to export all providers?"; 
 $Text['msg_err_upload'] = "An error occurred during uploading the file "; 
 $Text['msg_import_matchcol'] = "Need to match up database entries with table rows! Please assign the required matching column "; //+ here then comes the name of the matching column, e.g. custom_product_ref

--- a/local_config/lang/es.php
+++ b/local_config/lang/es.php
@@ -697,8 +697,14 @@ $Text['msg_finalize'] = "Está a punto de terminar un pedido. Esto significa que
 $Text['msg_finalize_open'] = "Este pedido está todavía abierto. Finalizar-lo implica que deberá cerrarlo antes de su fecha límite. ¿Está seguro de continuar?";
 $Text['msg_wait_tbl'] = "Las cabeceras de la tabla todavía se estan creando. En función de su conexión de internet puede llevar un tiempo.  Inténtelo otra vez en 5 segundos. ";
 $Text['msg_err_invalid_id'] = "¡No se encontró ningún ID válido para el pedido! ¡¡Este pedido no ha sido enviado al proveedor!!";
-$Text['msg_revise_revised'] = "Los ítems de este pedido han sido revisados y asignados a las cestas para la fecha de venta indicada.  Revisarlos otra vez implica perder la modificaciones ya hechas y interferir en las correcciones creadas por los usuarios. <br/><br/> ¡¡¿Está totalmente seguro de continuar?!! <br/><br/> Si pulsa OK borrará los ítems de las cestas existentes y iniciará el proceso de revisión del pedido otra vez.";
+$Text['msg_revise_revised'] =
+    "Los elementos del pedido ya han sido revisados y cargados en las cestas de los usuarios. <br>
+    Volverlos a revisar puede interferir con modificaciones hechas por los propios usuarios. <br>
+    Las opciones posibles son o <b>modificar</b> la revisión hecha o <b>borrarla</b> y empezar de nuevo.";
+$Text['btn_modify'] = "Modificar";
+$Text['btn_delete'] = "Borrar";
 $Text['wait_reset'] = "Por favor, espere mientras el pedido se reinicia...";
+$Text['msg_done'] = "Hecho!";
 $Text['msg_err_already_val'] = "Algunos o todos los ítems ya han sido validados! ¡¡Lo siento pero no es posible hacer mas cambios!!";
 $Text['print_several'] = "There is more than one order currently selected. Do you want to print them all in one go?";
 $Text['btn_yes_all'] = "Sí, imprimir todo";
@@ -748,8 +754,10 @@ $Text['total_after_revision'] = "Después de revisión";
 $Text['delivery_ref'] = "Ref. de entrega";
 $Text['payment_ref'] = "Ref. de pago";
 $Text['arrived'] = "Llegado"; //as in order items have arrived. this is a table heading
+$Text['tit_set_orStatus'] = "Establecer estado del pedido";
+$Text['tit_set_shpDate'] = "Establecer fecha de compra";
 $Text['msg_cur_status'] = "El estado actual del pedido es";
-$Text['msg_change_status'] = "Cambiar el estado del pedido a alguna de las siguientes opciones";
+$Text['msg_change_status'] = "Cambia el estado a";
 $Text['msg_confirm_move'] = "¿Está seguro de que quiere hacer disponible el pedido para la compra? Todos los productos asociados seran distribuidos en las cestas para la fecha:";
 $Text['alter_date'] = "Escoja una fecha alternativa";
 $Text['msg_err_miss_info'] = "Aparentemente este pedido fue creado con una versión más antigua del software que es incompatible con la funcionalidad de revisión actual.  Lo siento, este pedido no puede ser revisado.";
@@ -923,6 +931,8 @@ $Text['stock_info_product'] = "Nota: se pueden consultar todos los cambios de st
 
 
 $Text['msg_success'] = "Fin correcto";
+$Text['msg_confirm'] = "Confirmación";
+$Text['msg_warning'] = "Advertencia";
 $Text['msg_confirm_prov'] = "¿Seguro que quieres exportar todos los proveedores?"; 
 $Text['msg_err_upload'] = "Se ha producido un error en la carga del archivo "; 
 $Text['msg_import_matchcol'] = "Hay que hacer coincidir las entradas de la base de datos con las filas de la tabla. Debes asignar la columna que corresponde a "; //+ here then comes the name of the matching column, e.g. custom_product_ref

--- a/manage_orders.php
+++ b/manage_orders.php
@@ -32,19 +32,15 @@
         }
     </style>
     
-    <?php if (isset($_SESSION['dev']) && $_SESSION['dev'] == true ) { ?> 
-	    <script type="text/javascript" src="js/jquery/jquery.js"></script>
-		<script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-		<script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-		<script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-	   	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>   	
-	   	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
-	   	<script type="text/javascript" src="js/tablesorter/jquery.tablesorter.js" ></script>
-	   	<script type="text/javascript" src="js/jeditable/jquery.jeditable.mini.js" ></script>
-	   	  
-   	<?php  } else { ?>
-	   	<script type="text/javascript" src="js/js_for_manage_orders.min.js"></script>
-    <?php }?>
+    <script type="text/javascript" src="js/jquery/jquery.js"></script>
+    <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
+    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
+    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>
+    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
+    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <script type="text/javascript" src="js/tablesorter/jquery.tablesorter.js" ></script>
+    <script type="text/javascript" src="js/jeditable/jquery.jeditable.mini.js" ></script>
+    <script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>
      
 	<script type="text/javascript">
         // Texts of the literals in the language of the user. For use in js.
@@ -66,6 +62,8 @@
             _net_price:      "<?php echo $Text['or_net_price']; ?>",
             _net_total:      "<?php echo $Text['or_net_total']; ?>",
             _saving:         "<?php echo $Text['or_saving']; ?>",
+            _confirm:        "<?php echo $Text['msg_confirm']; ?>",
+            _warning:        "<?php echo $Text['msg_warning']; ?>",
             _click_to_edit_total: "<?php echo $Text['or_click_to_edit_total']; ?>",
             _click_to_edit_gprice:"<?php echo $Text['or_click_to_edit_gprice']; ?>"
         };
@@ -112,6 +110,9 @@
 
 			//order revision status states. 
 			var gRevStatus = [null, 'finalized','revised','postponed','canceled','revisedMod'];
+			var gRevStatusI18n = [null, local_lang.ostat_desc_sent, local_lang.ostat_desc_nochanges, local_lang.ostat_desc_postponed, local_lang.ostat_desc_cancel, local_lang.ostat_desc_changes];
+			var gRevStatusClass = ['dim40', 'isSend','asOrdered','postponed','orderCanceled','withChanges'];
+
 
 
 			//if this page has been called from torn...
@@ -489,6 +490,7 @@
 									$( this ).dialog( "close" );
 								}
 							},
+							title: local_lang._confirm,
 							type: 'confirm'});
 
 					}
@@ -505,9 +507,13 @@
 							type: "POST",
 							url: 'php/ctrl/Orders.php?oper=moveOrderToShop&order_id='+gSelRow.attr('orderId')+'&date='+$.getSelectedDate('#datepicker'),
 							success: function(txt){
+								$('.ui-dialog-buttonpane button', $this.parent()).hide();
+								$('#showDatePicker').hide();
 								$('.success_msg').show().next().hide();
 								$this.button('disable');
 								setTimeout(function(){
+									$('.ui-dialog-buttonpane button', $this.parent()).show();
+									$('#showDatePicker').show();
 									$this.dialog( "close" )
 									$('.interactiveCell').hide();
 									$('.success_msg').hide().next().show();
@@ -548,6 +554,7 @@
 						if ($.getSelectedDate('#datepicker2') == $.datepicker.formatDate('yy-mm-dd', gToday)){
 							$.showMsg({
 								msg:"Please select an order date starting from at least tomorrow onwards.",
+								title: local_lang._warning,
 								type: 'warning'});
 							return false; 
 						}
@@ -797,6 +804,7 @@
 					} else {
 						$.showMsg({
 							msg:"<?=$Text['msg_err_edit_order'];?>",
+							title: local_lang._warning,
 							type: 'warning'});
 					}
 				})
@@ -986,6 +994,7 @@
 					if (rowCount == 0){
 						$.showMsg({
 							msg:"<?=$Text['msg_err_order_filter'];?>",
+							title: local_lang._warning,
 							type: 'warning'});
 					}
 					$('#tbl_orderOverview tbody tr:even').addClass('rowHighlight');
@@ -1023,9 +1032,10 @@
 								"<?=$Text['btn_cancel'];?>" : function(){
 										$( this ).dialog( "close" );
 									}
-								},
-						type: 'warning'});
-
+							},
+							title: local_lang._warning,
+							type: 'warning'
+						});
 
 					e.stopPropagation();
 
@@ -1066,6 +1076,7 @@
 								$( this ).dialog( "close" );
 							}
 						},
+						title: local_lang._confirm,
 						type: 'confirm'});
 					
 					e.stopPropagation();
@@ -1161,27 +1172,31 @@
 							//test fails!! 
 							//alert("has cart " + hasCart + "  isvalidated "  + isValidated);
 							if (hasCart && !isValidated){
+								var _reset_butt = function(clear) {
+									return function() {
+										$('.ui-dialog-buttonpane button', $(this).parent()).hide();
+										$(this).html('<?=$Text['wait_reset'];?>');
+										gSelRow.children().eq(8).attr('revisionStatus',1);
+										var $this = $(this);
+										resetOrder(gSelRow.attr('orderId'), clear, function(){
+											$this.html('<?=$Text['msg_done'];?>');
+											setTimeout(function(){
+												switchTo('review', {});
+												$this.dialog("close");
+											}, 1000);
+										});
+									};
+								};
 								$.showMsg({
-									msg:"<?=$Text['msg_revise_revised'];?>",
+									msg:"<?php echo str_replace(array("\n","\r" ),array("\\n","\\r"),$Text['msg_revise_revised']); ?>",
 									buttons: {
-										"<?=$Text['btn_ok'];?>":function(){	
-											//reset this order to "finalized"
-											$(this).html('<?=$Text['wait_reset'];?>');
-											gSelRow.children().eq(8).attr('revisionStatus',1);
-											var $this = $(this);
-											resetOrder(gSelRow.attr('orderId'), function(){
-												$this.html('Done!');
-												setTimeout(function(){
-													switchTo('review', {});
-													$this.dialog("close");
-												}, 1000);
-												
-											});					
-										},
-										"<?=$Text['btn_cancel'];?>" : function(){
+										"<?php echo $Text['btn_modify'];?>": _reset_butt(false),
+										"<?php echo $Text['btn_delete'];?>": _reset_butt(true),
+										"<?php echo $Text['btn_cancel'];?>" : function(){
 											$( this ).dialog( "close" );
 										}
 									},
+									title: local_lang._warning,
 									type: 'warning'});
 
 							} else if (isValidated){
@@ -1226,8 +1241,9 @@
 										$(this).dialog("close");
 									}
 								},
+								title: local_lang._warning,
 								type: 'warning'});
-	        			} else {
+						} else {
 
 
 		        		
@@ -1392,7 +1408,7 @@
 				
 					switch(td.text()){
 						case "1": 
-							td.attr("title",local_lang.ostat_desc_sent).html('<span class="tdIconCenter ui-icon ui-icon-mail-closed"></span>');
+							td.attr("title",local_lang.ostat_desc_sent).addClass('isSend').html('<span class="tdIconCenter ui-icon ui-icon-mail-closed"></span>');
 							break;
 						case "2": 
 							td.attr("title",local_lang.ostat_desc_nochanges).addClass('asOrdered').html('<span class="tdIconCenter ui-icon ui-icon-check"></span>');
@@ -1432,6 +1448,7 @@
 									$(this).dialog("close");
 								}
 							},
+							title: local_lang._warning,
 							type: 'warning'});
 					} else {
 
@@ -1504,10 +1521,11 @@
 				 *	if an already revised order is changed in its status (again revised, postponed, etc.) 
 				 *  need to make sure that already distributed items get deleted. 
 				 */
-				function resetOrder(orderId, callbackfn){
+				function resetOrder(orderId, clear, callbackfn){
 					$.ajax({
 						type: "POST",
-						url: 'php/ctrl/Orders.php?oper=resetOrder&order_id='+orderId,
+						url: 'php/ctrl/Orders.php?oper=resetOrder&order_id='+orderId+
+							'&clear='+(clear?1:0),
 						success: function(txt){
 							callbackfn.call(this);
 						},
@@ -1517,7 +1535,7 @@
 								type: 'error'});
 							
 						}
-					});		
+					});
 
 				}
 
@@ -1548,7 +1566,11 @@
 
 							$('#dialog_orderStatus button').button('enable');
 							$('#btn_'+gRevStatus[sindex]).button('disable');
-							$('#currentOrderStatus').html(gRevStatus[sindex]);
+							$('#currentOrderStatus')
+								.html(gRevStatusI18n[sindex])
+								.removeClass()
+								.addClass("ui-corner-all aix-style-padding3x3 "+
+									gRevStatusClass[sindex]);
 							$('#dialog_orderStatus').dialog("open");
 							$('.orderTotals').hide();
 							$('#tbl_reviseOrder').hide();
@@ -1922,9 +1944,9 @@
 </div>
 <!-- end of wrap -->
 
-<div id="dialog_orderStatus" title="Set Order Status">
+<div id="dialog_orderStatus" title="<?php echo $Text['tit_set_orStatus'] ?>">
 	<p>&nbsp;</p>
-	<p><?php echo $Text['msg_cur_status'];?>: <span id="currentOrderStatus" class="ui-state-highlight ui-corner-all aix-style-padding3x3"></span>.</p>
+	<p><?php echo $Text['msg_cur_status'];?>: <span id="currentOrderStatus" class="ui-corner-all aix-style-padding3x3"></span>.</p>
 	<p><?php echo $Text['msg_change_status']; ?>: </p>
 	<p>&nbsp;</p>
 	<table>
@@ -1945,7 +1967,7 @@
 	<div id="datepicker2"></div>
 </div>
 
-<div id="dialog_setShopDate" title="Set shopping date">
+<div id="dialog_setShopDate" title="<?php echo $Text['tit_set_shpDate']; ?>">
 	<p>&nbsp;</p>
 	<p class="success_msg aix-style-ok-green ui-corner-all aix-style-padding8x8"><?php echo $Text['msg_move_to_shop']; ?></p>
 	<p><?php echo $Text['msg_confirm_move']; ?></p>

--- a/php/ctrl/Orders.php
+++ b/php/ctrl/Orders.php
@@ -115,7 +115,7 @@ try{
   			exit;
   			
   		case 'resetOrder':
-  			echo do_stored_query('reset_order_revision', get_param('order_id'));
+            reset_order_to_shop(get_param_int('order_id'), get_param_int('clear'));
   			exit;
   			
   		case 'editOrderDetailInfo':


### PR DESCRIPTION
Additionally:
 * It has translated the texts found only in English.
 * The dates appear translated.
 * The usage of configuration parameter `$development` and `$_SESSION['dev']` is removed from `manage_orders.php`, because for years is outdated in the `make` code to minimize js (many pages have no generated the corresponding `js_for_%.min.js`, so this is cause for comment on another issue)
 * The dialog buttons are inhibited when the dialog is used to then display the status of a ajax response.
 * Prevents there are no empty carts after erasing the distribution.