### PR TITLE
Review orders: At distribution not always status assigned is correct.

### DIFF
--- a/sql/queries/aixada_queries_order.sql
+++ b/sql/queries/aixada_queries_order.sql
@@ -519,7 +519,7 @@ begin
 	/**checks if quantities have changed between original order and revised one by computing difference for each quantity row **/
 	set qu_diff = ( select
 						sum(abs(oi.quantity - ( select 
-													os.quantity 
+													os.quantity * os.arrived
 												from 
 													aixada_order_to_shop os
 												where 


### PR DESCRIPTION
If at review an order some product are checked as not arrived (but without changing any quantity) when distribution is made the status is set as "revised unchanged", oops!