### PR TITLE
When reopens an order, must delete "aixada_order_to_shop".

### DIFF
--- a/sql/queries/aixada_queries_order.sql
+++ b/sql/queries/aixada_queries_order.sql
@@ -842,6 +842,11 @@ begin
 
 	/** delete order **/
 	delete from 
+		aixada_order_to_shop
+	where
+		order_id = the_order_id;
+
+	delete from 
 		aixada_order
 	where
 		id = the_order_id; 


### PR DESCRIPTION
If is started a review of the order and order is reopen then aixada_order is not deleted (due to constrains integrity) and there are also zomby records on "aixada_order_to_shop" with the order_id reopened.