### PR TITLE
Proposal: Allows configure to directly distribute and validate orders.

### DIFF
--- a/local_config/config.php.sample
+++ b/local_config/config.php.sample
@@ -115,7 +115,20 @@ class configuration_vars {
    */
   public $order_review_uf_sequence = 'desc';
   
+  /**
+   * Possible methods of distributing orders are: 'only_distribute',
+   *    'distribute_and_validate' and 'choice' (both are available),
+   *     default is 'only_distribute'.
+   */
+  public $order_distribution_method = 'distribute_and_validate';
   
+  /**
+   * When the method 'distribute_and_validate' is used can also record the
+   * provider note as invoice into account provider, default is true
+   * (requires option `$accounts['use_providers'] = true` to take effect)
+   */
+  public $order_distributeValidate_invoce = true;
+
   /**
    * 
    * the default jquery-ui theme. these are located in css/ui-themes

--- a/local_config/lang/ca-va.php
+++ b/local_config/lang/ca-va.php
@@ -698,6 +698,7 @@ $Text['msg_con_disValitate_prvInv'] =
 $Text['msg_err_disValitate'] = "Error al distribuir i validar la comanda #";
 $Text['btn_disValitate_ok'] = "Entesos: distribueix i valida!";
 $Text['btn_bakToRevise'] = "Encara no: vull seguir revisant";
+$Text['btn_disValitate_done'] = "Correcte!<br>La comanda #{order_id} ha estat distribuida i validada.";
 $Text['wait_work'] = "Si us plau, espera mentre es fa la feina...";
 $Text['msg_err_edit_order'] = "Aquesta comanda no està completada. Només pots desar les notes i referències quan la comanda s'hagi enviat.";
 $Text['order_open'] = "La comanda està oberta";

--- a/local_config/lang/ca-va.php
+++ b/local_config/lang/ca-va.php
@@ -683,6 +683,22 @@ $Text['finished_loading'] = "Càrrega acabada";
 $Text['msg_err_unrevised'] = "Encara hi ha element pendents de revisar a la comanda. Si us plau, verifica que hagin arribat tots els productes!";
 $Text['btn_dis_anyway'] = "Distribueix igualment";
 $Text['btn_remaining'] = "Revisar els pendents";
+$Text['btn_disValitate'] = "Distribueix i valida";
+$Text['msg_con_disValitate'] =
+    "Distribuir i validar no es pot anular!!:<ul>
+    <li>s'anotaran els productes com a compres de les UF en la data de la comanda</li>
+    <li>i els imports de les compres s'anotarà com a deute als comptes de les UF</li>
+    </ul>";
+$Text['msg_con_disValitate_prvInv'] =
+    "Distribuir i validar no es pot anular!!:<ul>
+    <li>s'anotaran els productes com a compres de les UF en la data de la comanda,</li>
+    <li>els imports de les compres s'anotarà com a deute als comptes de les UF</li>
+    <li>i l'import de l'albarà s'anotará al compte del proveïdor com a factura.</li>
+    </ul>";
+$Text['msg_err_disValitate'] = "Error al distribuir i validar la comanda #";
+$Text['btn_disValitate_ok'] = "Entesos: distribueix i valida!";
+$Text['btn_bakToRevise'] = "Encara no: vull seguir revisant";
+$Text['wait_work'] = "Si us plau, espera mentre es fa la feina...";
 $Text['msg_err_edit_order'] = "Aquesta comanda no està completada. Només pots desar les notes i referències quan la comanda s'hagi enviat.";
 $Text['order_open'] = "La comanda està oberta";
 $Text['finalize_now'] = "Finalitza ara";

--- a/local_config/lang/en.php
+++ b/local_config/lang/en.php
@@ -705,6 +705,7 @@ $Text['msg_con_disValitate_prvInv'] =
 $Text['msg_err_disValitate'] = "Error when distribute and validate order #";
 $Text['btn_disValitate_ok'] = "Understood: distributes and validates!";
 $Text['btn_bakToRevise'] = "Not yet: I want to continue reviewing";
+$Text['btn_disValitate_done'] = "Right!<br>Order #{order_id} has been distributed and validated.";
 $Text['wait_work'] = "Please wait while the work is done...";
 $Text['msg_err_edit_order'] = "This order is not finalized. You can only save the notes and references once the order has been sent off.";
 $Text['order_open'] = "Order is open";

--- a/local_config/lang/en.php
+++ b/local_config/lang/en.php
@@ -690,6 +690,22 @@ $Text['finished_loading'] = "Finished loading";
 $Text['msg_err_unrevised'] = "There are still unrevised items in this order. Please make sure all ordered products have arrived!";
 $Text['btn_dis_anyway'] = "Distribute anyway";
 $Text['btn_remaining'] = "Revise remaining";
+$Text['btn_disValitate'] = "Distribute and validate";
+$Text['msg_con_disValitate'] =
+    "Distribute and validate can not cancel!!:<ul>
+    <li>the products will be put as purchases of UF on the date of the order</li>
+    <li>and the amount of the purchases will be put as a debt in the accounts of each HU</li>
+    </ul>";
+$Text['msg_con_disValitate_prvInv'] =
+    "Distribute and validate can not cancel!!:<ul>
+    <li>the products will be put as purchases of UF on the date of the order,</li>
+    <li>the amount of the purchases will be put as a debt in the accounts of each HU</li>
+    <li>and the total amount will be put as invoice to the provider account.</li>
+    </ul>";
+$Text['msg_err_disValitate'] = "Error when distribute and validate order #";
+$Text['btn_disValitate_ok'] = "Understood: distributes and validates!";
+$Text['btn_bakToRevise'] = "Not yet: I want to continue reviewing";
+$Text['wait_work'] = "Please wait while the work is done...";
 $Text['msg_err_edit_order'] = "This order is not finalized. You can only save the notes and references once the order has been sent off.";
 $Text['order_open'] = "Order is open";
 $Text['finalize_now'] = "Finalize now";

--- a/local_config/lang/es.php
+++ b/local_config/lang/es.php
@@ -689,6 +689,22 @@ $Text['finished_loading'] = "Carga Finalizada";
 $Text['msg_err_unrevised'] = "¡Hay items sin revisar en este pedido. Por favor, asegúrese de que todos los productos pedidos han llegado!";
 $Text['btn_dis_anyway'] = "Distribuir igualmente";
 $Text['btn_remaining'] = "Revisar los pendientes";
+$Text['btn_disValitate'] = "Distribuye y valida";
+$Text['msg_con_disValitate'] =
+    "Distribuir y validar no se puede anular!!:<ul>
+    <li>se anotarán los productos como compras de las UF en la fecha del pedido</li>
+    <li>y los importes de las compras se anotarán como deuda a las cuentas de las UF</li>
+    </ul>";
+$Text['msg_con_disValitate_prvInv'] =
+    "Distribuir y validar no se puede anular!!:<ul>
+    <li>se anotarán los productos como compras de las UF en la fecha del pedido,</li>
+    <li>los importes de las compras se anotarán como deuda a las cuentas de las UF</li>
+    <li>y el importe del albarán se anotará en la cuenta del proveedor como factura.</li>
+    </ul>";
+$Text['msg_err_disValitate'] = "Error al distribuir y validar el pedido #";
+$Text['btn_disValitate_ok'] = "Entendidos: distribuye y valida!";
+$Text['btn_bakToRevise'] = "Todavía no: quiero seguir revisando";
+$Text['wait_work'] = "Por favor, espera mientras se hace el trabajo...";
 $Text['msg_err_edit_order'] = "Este pedido no está completo. Solo se pueden añadir notas y referencias cuando se haya enviado.";
 $Text['order_open'] = "El Pedido está abierto";
 $Text['finalize_now'] = "Finalizar ahora";

--- a/local_config/lang/es.php
+++ b/local_config/lang/es.php
@@ -704,6 +704,7 @@ $Text['msg_con_disValitate_prvInv'] =
 $Text['msg_err_disValitate'] = "Error al distribuir y validar el pedido #";
 $Text['btn_disValitate_ok'] = "Entendidos: distribuye y valida!";
 $Text['btn_bakToRevise'] = "Todavía no: quiero seguir revisando";
+$Text['btn_disValitate_done'] = "Correcto!<br>El pedido #{order_id} ha sido distribuido y validado.";
 $Text['wait_work'] = "Por favor, espera mientras se hace el trabajo...";
 $Text['msg_err_edit_order'] = "Este pedido no está completo. Solo se pueden añadir notas y referencias cuando se haya enviado.";
 $Text['order_open'] = "El Pedido está abierto";

--- a/manage_orders.php
+++ b/manage_orders.php
@@ -573,20 +573,24 @@
                                 url: 'php/ctrl/Orders.php?oper=directlyValidateOrder&order_id='+_orderId+
                                     '&record_provider_invoice='+local_cfg.record_provider_invoice,
                                 success: function(txt){
-                                    $this.html("<?=i18n('msg_done');?>");
-                                    setTimeout( function() {
-                                        //reload order list
-                                        switchTo('overview');
-                                        $('#tbl_orderOverview tbody').xml2html('reload');
-                                        $this.dialog("close");
-                                    }, 1000);
+                                    $this.dialog("close");
+                                    //reload order list
+                                    $('#tbl_orderOverview tbody').xml2html('reload');
+                                    switchTo('overview');
+                                    $.showMsg({
+                                        msg: txt,
+                                        autoclose: 3000,
+                                        buttons: {},
+                                        title: "<?php echo $Text['msg_success']; ?>",
+                                        type: 'success'
+                                    });
                                 },
                                 error : function(XMLHttpRequest, textStatus, errorThrown){
                                     switchTo('overview');
                                     $this.dialog("close");
                                     $.showMsg({
                                         msg: "<?=i18n('msg_err_disValitate');?>"+ _orderId +
-                                            "<hr>" + XMLHttpRequest.responseText,
+                                            "<hr><br>" + XMLHttpRequest.responseText,
                                         type: 'error'});
                                 }
                             });

--- a/php/ctrl/Orders.php
+++ b/php/ctrl/Orders.php
@@ -95,6 +95,11 @@ try{
 			prepare_order_to_shop(get_param_int('order_id'));
     		echo do_stored_query('move_order_to_shop', get_param('order_id'), get_param('date'));
     		exit;
+            
+    	//Distribute and directly validate an order
+    	case 'directlyValidateOrder':
+    		directly_validate_order(get_param_int('order_id'));
+    		exit;
     		
     	//retrieves info about originally ordered quanties and available items after received orders have been revised and distributed in carts. 
   		case 'getDiffOrderShop':

--- a/php/ctrl/Orders.php
+++ b/php/ctrl/Orders.php
@@ -98,7 +98,7 @@ try{
             
     	//Distribute and directly validate an order
     	case 'directlyValidateOrder':
-    		directly_validate_order(get_param_int('order_id'));
+    		directly_validate_order(get_param_int('order_id'), get_param_int('record_provider_invoice', 0));
     		exit;
     		
     	//retrieves info about originally ordered quanties and available items after received orders have been revised and distributed in carts. 

--- a/php/ctrl/Orders.php
+++ b/php/ctrl/Orders.php
@@ -98,7 +98,7 @@ try{
             
     	//Distribute and directly validate an order
     	case 'directlyValidateOrder':
-    		directly_validate_order(get_param_int('order_id'), get_param_int('record_provider_invoice', 0));
+    		echo directly_validate_order(get_param_int('order_id'), get_param_int('record_provider_invoice', 0));
     		exit;
     		
     	//retrieves info about originally ordered quanties and available items after received orders have been revised and distributed in carts. 

--- a/php/lib/account_operations.php
+++ b/php/lib/account_operations.php
@@ -16,6 +16,11 @@ class account_operations {
     // --------------------------------------------
     // READ
     // --------------------------------------------
+
+    public function uses_providers() {
+        return $this->cfg_use_providers;
+    }
+
     public function latest_movements_XML($limit, $account_types) {
 		return rs_XML_fields(
 			$this->latest_movements_rs($limit, $account_types),

--- a/php/lib/validation_cart_manager.php
+++ b/php/lib/validation_cart_manager.php
@@ -38,7 +38,7 @@ class validation_cart_manager extends shop_cart_manager {
  protected function _postprocessing($arrQuant, $arrProdId, $arrIva, $arrRevTax, $arrOrderItemId, $cart_id, $arrPreOrder, $arrPrice)
   {
     //do_stored_query('deduct_stock_and_pay', $cart_id);
-    do_stored_query('validate_shop_cart', $cart_id, $this->_op_id, 'cart #');
+    do_stored_query('validate_shop_cart', $cart_id, $this->_op_id, 'cart #', 1);
   }
 
 }

--- a/php/lib/validation_cart_manager.php
+++ b/php/lib/validation_cart_manager.php
@@ -38,7 +38,7 @@ class validation_cart_manager extends shop_cart_manager {
  protected function _postprocessing($arrQuant, $arrProdId, $arrIva, $arrRevTax, $arrOrderItemId, $cart_id, $arrPreOrder, $arrPrice)
   {
     //do_stored_query('deduct_stock_and_pay', $cart_id);
-    do_stored_query('validate_shop_cart', $cart_id, $this->_op_id);
+    do_stored_query('validate_shop_cart', $cart_id, $this->_op_id, 'cart #');
   }
 
 }

--- a/php/utilities/orders.php
+++ b/php/utilities/orders.php
@@ -332,109 +332,108 @@ function directly_validate_order($order_id, $record_provider_invoice) {
     
     prepare_order_to_shop(get_param_int('order_id'));
     $db = DBWrap::get_instance();
-    $db->start_transaction(); // $db->commit() and $db->rollback()
-    
-    // Set date for shop as date for order
-    $row_or = get_row_query(
-        "select provider_id, date_for_order 
-        from aixada_order where id = {$order_id};");
-    $date_for_shop = $row_or['date_for_order'];
-    $provider_id = $row_or['provider_id'];
-    
-    $operator_id = get_session_user_id();
-    //For each uf    
-    $rs = $db->Execute("select distinct os.uf_id
-            from aixada_order_to_shop os
-            where os.arrived = 1 and os.order_id = {$order_id};");
-    $carts = array();
-    while ($row = $rs->fetch_assoc()) {
-        $uf_id = $row['uf_id'];
-        // Create cart
-        $db->Execute(
-            "insert into aixada_cart (
-                uf_id, date_for_shop
-            )
-            values (
-                {$uf_id}, '{$date_for_shop}'
-            );"
-        );
-        $cart_id = $db->last_insert_id();
-        array_push($carts, $cart_id);
-        // Copy revised items into aixada_shop_item with to corresponding cart
-        $db->Execute(
-            "insert into aixada_shop_item (
-                cart_id, order_item_id, unit_price_stamp, product_id,
-                quantity, iva_percent, rev_tax_percent)
-            select
-                {$cart_id}, 
-                os.order_item_id,
-                os.unit_price_stamp,
-                os.product_id,
-                os.quantity, 
-                iva_percent,
-                rev_tax_percent
-            from
-                aixada_order_to_shop os
-            where 
-                os.order_id = {$order_id}
-                and os.uf_id = {$uf_id}
-                and os.arrived = 1;"
-        );
+    try {
+        $db->start_transaction();
         
-        // If quantities have changed, revision status is 5; otherwise it is 2.
-        $qu_diff_row = get_row_query(
-            "select sum(abs(oi.quantity - (
-                select os.quantity * os.arrived
+        // Set date for shop as date for order
+        $row_or = get_row_query(
+            "select provider_id, date_for_order 
+            from aixada_order where id = {$order_id};");
+        $date_for_shop = $row_or['date_for_order'];
+        $provider_id = $row_or['provider_id'];
+        
+        $operator_id = get_session_user_id();
+        //For each uf
+        $rs = $db->Execute("select distinct os.uf_id
                 from aixada_order_to_shop os
-                where os.order_id = {$order_id}
-                      and os.order_item_id = oi.id) ) ) qu_diff
-            from aixada_order_item oi
-            where oi.order_id = {$order_id};"
-        );
-        $db->Execute(
-            "update aixada_order
-            set
-                date_for_shop = '{$date_for_shop}',
-                revision_status = ".($qu_diff_row['qu_diff'] === 0 ? 2 : 5)."
-            where id = {$order_id};"
-        );
-    }
-    $db->commit();
-    
-    // Validate carts
-    // TODO: Only one transaction!!
-    //          Currently is not possible since 'validate_shop_cart' as
-    //          a own transaction
-    $desc_pay = "order#{$order_id} {$date_for_shop} cart#";
-    foreach ($carts as $cart) {
-        do_stored_query('validate_shop_cart', $cart, $operator_id, $desc_pay);
-    }
-    if ($record_provider_invoice) {
-        // Add provider invoice
-        $ao = new account_operations();
-        if ($ao->uses_providers()) {
-            $prv_tot_row = get_row_query(
-                "select sum( 
-                            quantity * 
-                            round( unit_price_stamp / (1 + rev_tax_percent/100), 2 )
-                        ) prv_tot from (
-                    select 
-                        sum(os.quantity) quantity, unit_price_stamp, rev_tax_percent, iva_percent
+                where os.arrived = 1 and os.order_id = {$order_id};");
+        while ($row = $rs->fetch_assoc()) {
+            $uf_id = $row['uf_id'];
+            // Create cart
+            $db->Execute(
+                "insert into aixada_cart (
+                    uf_id, date_for_shop
+                )
+                values (
+                    {$uf_id}, '{$date_for_shop}'
+                );"
+            );
+            $cart_id = $db->last_insert_id();
+            // Copy revised items into aixada_shop_item with to corresponding cart
+            $db->Execute(
+                "insert into aixada_shop_item (
+                    cart_id, order_item_id, unit_price_stamp, product_id,
+                    quantity, iva_percent, rev_tax_percent)
+                select
+                    {$cart_id}, 
+                    os.order_item_id,
+                    os.unit_price_stamp,
+                    os.product_id,
+                    os.quantity, 
+                    iva_percent,
+                    rev_tax_percent
+                from
+                    aixada_order_to_shop os
+                where 
+                    os.order_id = {$order_id}
+                    and os.uf_id = {$uf_id}
+                    and os.arrived = 1;"
+            );
+            
+            // If quantities have changed, revision status is 5; otherwise it is 2.
+            $qu_diff_row = get_row_query(
+                "select sum(abs(oi.quantity - (
+                    select os.quantity * os.arrived
                     from aixada_order_to_shop os
-                    where 
-                        os.order_id = {$order_id}
-                        and os.arrived = 1
-                    group by
-                        unit_price_stamp, rev_tax_percent, iva_percent) r;"
+                    where os.order_id = {$order_id}
+                          and os.order_item_id = oi.id) ) ) qu_diff
+                from aixada_order_item oi
+                where oi.order_id = {$order_id};"
             );
-            $ao->add_operation(
-                'invoice_pr',
-                array('provider_from_id' => $provider_id + 2000),
-                $prv_tot_row['prv_tot'], 
-                "validation order#{$order_id} {$date_for_shop}"
+            $db->Execute(
+                "update aixada_order
+                set
+                    date_for_shop = '{$date_for_shop}',
+                    revision_status = ".($qu_diff_row['qu_diff'] === 0 ? 2 : 5)."
+                where id = {$order_id};"
             );
+            // Validate carts
+            do_stored_query('validate_shop_cart', $cart_id, $operator_id, 
+                    "order#{$order_id} {$date_for_shop} cart#", 0);
         }
-    }
+        if ($record_provider_invoice) {
+            // Add provider invoice
+            $ao = new account_operations();
+            $ao->use_transaction = false;
+            if ($ao->uses_providers()) {
+                $prv_tot_row = get_row_query(
+                    "select sum( 
+                                quantity * 
+                                round( unit_price_stamp / (1 + rev_tax_percent/100), 2 )
+                            ) prv_tot from (
+                        select 
+                            sum(os.quantity) quantity, unit_price_stamp, rev_tax_percent, iva_percent
+                        from aixada_order_to_shop os
+                        where 
+                            os.order_id = {$order_id}
+                            and os.arrived = 1
+                        group by
+                            unit_price_stamp, rev_tax_percent, iva_percent) r;"
+                );
+                $ao->add_operation(
+                    'invoice_pr',
+                    array('provider_from_id' => $provider_id + 2000),
+                    $prv_tot_row['prv_tot'], 
+                    "validation order#{$order_id} {$date_for_shop}"
+                );
+            }
+        }
+        $db->commit();
+    } catch (Exception $e) {
+        $db->rollback();
+        throw new Exception($e->getMessage());
+    } 
+    return i18n('btn_disValitate_done', array('order_id'=>$order_id));
 }
 
 

--- a/sql/queries/aixada_queries_validate.sql
+++ b/sql/queries/aixada_queries_validate.sql
@@ -70,13 +70,15 @@ end|
  * and registers the money in the corresponding accounts.  
  */
 drop procedure if exists validate_shop_cart|
-create procedure validate_shop_cart(in the_cart_id int, in the_op_id int, in the_desc_pay varchar(50))
+create procedure validate_shop_cart(in the_cart_id int, in the_op_id int, in the_desc_pay varchar(50), in use_transaction boolean)
 begin
   declare current_balance decimal(10,2) default 0.0;
   declare total_price decimal(10,2) default 0.0;
   declare the_account_id int;
   
-  start transaction;
+  if (use_transaction is true) then
+    start transaction;
+  end if;
   
   set the_account_id = (
 	  select
@@ -137,8 +139,9 @@ begin
     concat(the_desc_pay, the_cart_id),
     the_op_id,
     current_balance - total_price;
-    
+  if (use_transaction is true) then
    commit;
+  end if;
 
 end|
 

--- a/sql/queries/aixada_queries_validate.sql
+++ b/sql/queries/aixada_queries_validate.sql
@@ -70,7 +70,7 @@ end|
  * and registers the money in the corresponding accounts.  
  */
 drop procedure if exists validate_shop_cart|
-create procedure validate_shop_cart(in the_cart_id int, in the_op_id int)
+create procedure validate_shop_cart(in the_cart_id int, in the_op_id int, in the_desc_pay varchar(50))
 begin
   declare current_balance decimal(10,2) default 0.0;
   declare total_price decimal(10,2) default 0.0;
@@ -134,7 +134,7 @@ begin
    the_account_id,
     - total_price,
     6,
-    concat('cart #', the_cart_id),
+    concat(the_desc_pay, the_cart_id),
     the_op_id,
     current_balance - total_price;
     


### PR DESCRIPTION
For some cooperatives (ours, Travalera and Guixa -which is studying launch Aixada--) the verification products from orders in a second step after the distribution is not necessary.
The proposal adds this feature, is configurable and is disabled by default.