### PR TITLE
Fix inaccuracy: By default use configuration 'only_distribute'

### DIFF
--- a/local_config/config.php.sample
+++ b/local_config/config.php.sample
@@ -127,7 +127,7 @@ class configuration_vars {
    *    'distribute_and_validate' and 'choice' (both are available),
    *     default is 'only_distribute'.
    */
-  public $order_distribution_method = 'distribute_and_validate';
+  public $order_distribution_method = 'only_distribute';
   
   /**
    * When the method 'distribute_and_validate' is used can also record the


### PR DESCRIPTION
After adding into configuration the `$order_distribution_method` this is the option that keeps the previous operation.