### PR TITLE
Make more explicit the UI of reopen order

### DIFF
--- a/local_config/lang/ca-va.php
+++ b/local_config/lang/ca-va.php
@@ -1020,5 +1020,12 @@ $Text['or_click_to_edit_total'] = 'Clic per ajustar la quantitat total';
 $Text['or_click_to_edit_gprice'] = 'Clic per ajustar el preu';
 $Text['or_saving'] = 'Guardant';
 $Text['or_ostat_desc_validated'] = "Els productes d'aquesta comanda han estat validats";
-$Text['os_reopen_order'] = 'Estas segur que vols obre la comanda un altre vegada?';
+$Text['os_reopen_order_a'] = "Reobrir";
+$Text['os_reopen_order'] =
+    "Estas segur que vols reobrir aquesta comanda?<hr><br>
+    NOTA:<br>
+    La comanda pot haver estat enviada per correu.<br>
+    Si es torna a obrir
+    <b>cal parlar amb el proveïdor</b>
+    per dir-li que la comanda ha estat cancel·lada!";
 ?>

--- a/local_config/lang/en.php
+++ b/local_config/lang/en.php
@@ -1028,7 +1028,14 @@ $Text['or_click_to_edit_total'] = 'Click to adjust total quantities';
 $Text['or_click_to_edit_gprice'] = 'Click to adjust price';
 $Text['or_saving'] = 'Saving';
 $Text['or_ostat_desc_validated'] = 'Items of this order have been validated';
-$Text['os_reopen_order'] = 'Are you sure to reopen this order?';
+$Text['os_reopen_order_a'] = "Reopen";
+$Text['os_reopen_order'] =
+    "Are you sure to reopen this order?<hr><br>
+    NOTE:<br>
+    The order may have been mailed.<br>
+    If reopens order
+    <b>must talk with the provider</b>
+    to tell him that the order has been cancelled!";
 
 
 //$Text[''] = ""; 

--- a/local_config/lang/es.php
+++ b/local_config/lang/es.php
@@ -1028,6 +1028,13 @@ $Text['or_click_to_edit_total'] = 'Clic para ajustar la cantidad total';
 $Text['or_click_to_edit_gprice'] = 'Clic para ajustar el precio';
 $Text['or_saving'] = 'Guardando';
 $Text['or_ostat_desc_validated'] = 'Los productos de este pedido han sido validados';
-$Text['os_reopen_order'] = 'Estás seguro de re-abrir el pedido?';
+$Text['os_reopen_order_a'] = "Re-abrir";
+$Text['os_reopen_order'] =
+    "¿Seguro que deseas re-abrir este pedido?<hr><br>
+    NOTA:<br>
+    El pedido puede haberse enviado por correo.<br>
+    Si se vuelve a abrir
+    <b>se debe hablar con el proveedor</b>
+    para decirle que el pedido ha sido cancelado!";
 
 ?>

--- a/manage_orders.php
+++ b/manage_orders.php
@@ -1014,6 +1014,8 @@
 			 *		ORDER OVERVIEW FUNCTIONALITY
 			 **********************************************************/
 			//var timePeriod = (gFilter != '')? gFilter:'pastMonths2Future';
+			var _date_today = new Date();
+				_date_today.setHours(0,0,0,0);
 			$('#tbl_orderOverview tbody').xml2html('init',{
 				url : 'php/ctrl/Orders.php',
 				params : 'oper=getOrdersListing&filter='+gFilter, 
@@ -1033,7 +1035,7 @@
 						tds.eq(6).text('-');
 					}
 					
-					if (timeLeft > 0){ 	// order is still open
+					if (timeLeft >= 0){ // order is still open
 						tds.eq(8).html('<span class="tdIconCenter ui-icon ui-icon-unlocked" title="<?=$Text['order_open'];?>"></span>');
 
 					} else if (timeLeft < 0 && isPreorder){ //preorder is not closed 
@@ -1055,11 +1057,14 @@
 						//if order has been send but not yet received, it can be reopened
 						var statusTd = $(row).children().eq(8).attr('revisionStatus');
 						if (statusTd == 1){
-							tds.eq(6).html(
-								'<a href="javascript:void(null)" class="reopenOrderBtn">'+
-								'<?php echo i18n_js('os_reopen_order_a'); ?>'+' #'+orderId+
-								'</a>'
-							);
+							var date_for_order = new Date(tds.eq(3).text());
+							if (date_for_order.getTime() >= _date_today.getTime() || isPreorder) {
+								tds.eq(6).html(
+									'<a href="javascript:void(null)" class="reopenOrderBtn">'+
+									'<?php echo i18n_js('os_reopen_order_a'); ?>'+' #'+orderId+
+									'</a>'
+								);
+							}
 						}
 
 					} else {

--- a/manage_orders.php
+++ b/manage_orders.php
@@ -1014,14 +1014,16 @@
 			 *		ORDER OVERVIEW FUNCTIONALITY
 			 **********************************************************/
 			//var timePeriod = (gFilter != '')? gFilter:'pastMonths2Future';
-			var _date_today = new Date();
-				_date_today.setHours(0,0,0,0);
+			var _date_todayOverview;
 			$('#tbl_orderOverview tbody').xml2html('init',{
 				url : 'php/ctrl/Orders.php',
 				params : 'oper=getOrdersListing&filter='+gFilter, 
 				loadOnInit : true, 
 				beforeLoad : function(){
 					$('.loadSpinner').show();
+					// refresh date
+					_date_todayOverview = new Date();
+					_date_todayOverview.setHours(0,0,0,0);
 				},
 				rowComplete : function (rowIndex, row){
 					var tds = $(row).children();
@@ -1058,7 +1060,7 @@
 						var statusTd = $(row).children().eq(8).attr('revisionStatus');
 						if (statusTd == 1){
 							var date_for_order = new Date(tds.eq(3).text());
-							if (date_for_order.getTime() >= _date_today.getTime() || isPreorder) {
+							if (date_for_order.getTime() >= _date_todayOverview.getTime() || isPreorder) {
 								tds.eq(6).html(
 									'<a href="javascript:void(null)" class="reopenOrderBtn">'+
 									'<?php echo i18n_js('os_reopen_order_a'); ?>'+' #'+orderId+

--- a/manage_orders.php
+++ b/manage_orders.php
@@ -1055,7 +1055,11 @@
 						//if order has been send but not yet received, it can be reopened
 						var statusTd = $(row).children().eq(8).attr('revisionStatus');
 						if (statusTd == 1){
-							tds.eq(1).html('<a href="javascript:void(null)" class="reopenOrderBtn">'+orderId+'</a>');
+							tds.eq(6).html(
+								'<a href="javascript:void(null)" class="reopenOrderBtn">'+
+								'<?php echo i18n_js('os_reopen_order_a'); ?>'+' #'+orderId+
+								'</a>'
+							);
 						}
 
 					} else {
@@ -1083,7 +1087,7 @@
 					var orderId = $(this).parents('tr').attr("id");
 						
 						$.showMsg({
-							msg:"<?=$Text['os_reopen_order'];?>",
+							msg:"<?=i18n_js('os_reopen_order');?>",
 							buttons: {
 								"<?=$Text['btn_ok'];?>":function(){	
 										var $this = $(this);


### PR DESCRIPTION
But it allows reopen orders only until the date of delivery (included). Otherwise it is useless since last date of delivery orders can not be changed.

Also fix a small mismatch presentation that showed how `Closed` a order to close today, now as "Closes in days" shows `0` instead of `Closed`.
