### PR TITLE
validation.php: Allows create a empty cart at validation

### DIFF
--- a/js/aixadacart/jquery.aixadacart.js
+++ b/js/aixadacart/jquery.aixadacart.js
@@ -352,7 +352,8 @@
     		 }
     			 
     		 $this.aixadacart("options",options);
-    		 
+    		 _loadCartHeadURL = (options.loadCartHeadURL ?
+                    options.loadCartHeadURL : null);
     		 $this.data('aixadacart').isLoading = true;
     		 $('#cart .cartLoadAnim').show();
     		 
@@ -380,8 +381,27 @@
 			  		 
 			  		});// end each row	
     			 	
-    			 	$('#global_cart_id').val(lastCartId);
-    			 	$('#global_ts_last_saved').val(ts_last_saved);
+                    if (lastCartId === -1 && _loadCartHeadURL) {
+                        // Is a empty cart but is set loadCartHeadURL option.
+                        $.ajax({ 
+                            type:"GET", 
+                            url: _loadCartHeadURL,
+                            dataType: "xml",
+                            success: function(xml){
+                                var lastCartId = -1;
+                                var ts_last_saved = 0; 
+                                $(xml).find('row').each(function(){
+                                    lastCartId = $(this).find('cart_id').text();
+                                    ts_last_saved = $(this).find('ts_last_saved').text();
+                                });
+                                $('#global_cart_id').val(lastCartId);
+                                $('#global_ts_last_saved').val(ts_last_saved);
+                            }
+                        });
+                    } else {
+                        $('#global_cart_id').val(lastCartId);
+                        $('#global_ts_last_saved').val(ts_last_saved);
+                    }
     			 	
     			 	$this.data('aixadacart').loadSuccess.call(this);
     			 	$this.data('aixadacart').unsavedItems = false;

--- a/local_config/config.php.sample
+++ b/local_config/config.php.sample
@@ -96,6 +96,16 @@ class configuration_vars {
    * @var boolean
    */  
   public $validate_show_carts = 'day';
+
+  /**
+   * Allows create a empty cart at validation. This is usefully to assign
+   *    products to a UF with no orders and no shop or when is used the
+   *    option `$order_distribution_method = 'distribute_and_validate'`.
+   * If is true a button "Create cart" is displayed when is select a UF without
+   *    not validated carts (default value is false)
+   * @var boolean
+   */  
+  public $validate_btn_create_carts = false;
  
   /**
    * 

--- a/local_config/lang/ca-va.php
+++ b/local_config/lang/ca-va.php
@@ -478,6 +478,9 @@ $Text['msg_no_active_products'] = "En aquests moments no hi ha productes actius 
 $Text['msg_delete_incident'] = "Segur que voleu eliminar aquest incident?";
 //$Text['msg_err_selectFirstUF'] = "No hi ha UF seleccionada. Selecciona una primer i després les seves compres."; //ADDED JAN 2012
 
+$Text['click_to_change'] = "Clic per canviar!";
+$Text['cart_date'] = "Data de la cistella";
+$Text['create_cart'] = "Crear Cistella";
 
 /**
  *  Product categories
@@ -694,12 +697,12 @@ $Text['msg_con_disValitate_prvInv'] =
     "Distribuir i validar no es pot anular!!:<ul>
     <li>s'anotaran els productes com a compres de les UF en la data de la comanda,</li>
     <li>els imports de les compres s'anotarà com a deute als comptes de les UF</li>
-    <li>i l'import de l'albarà s'anotará al compte del proveïdor com a factura.</li>
+    <li>i l'import de l'albarà s'anotarà al compte del proveïdor com a factura.</li>
     </ul>";
 $Text['msg_err_disValitate'] = "Error al distribuir i validar la comanda #";
 $Text['btn_disValitate_ok'] = "Entesos: distribueix i valida!";
 $Text['btn_bakToRevise'] = "Encara no: vull seguir revisant";
-$Text['btn_disValitate_done'] = "Correcte!<br>La comanda #{order_id} ha estat distribuida i validada.";
+$Text['btn_disValitate_done'] = "Correcte!<br>La comanda #{order_id} ha estat distribuïda i validada.";
 $Text['wait_work'] = "Si us plau, espera mentre es fa la feina...";
 $Text['msg_err_edit_order'] = "Aquesta comanda no està completada. Només pots desar les notes i referències quan la comanda s'hagi enviat.";
 $Text['order_open'] = "La comanda està oberta";

--- a/local_config/lang/en.php
+++ b/local_config/lang/en.php
@@ -481,6 +481,9 @@ $Text['msg_no_active_products'] = "Sorry, but currently there are no products ac
 $Text['msg_delete_incident'] = "Are you sure you want to delete this incident?";
 //$Text['msg_err_selectFirstUF'] = "There is no household selected. Choose one first and then its purchases."; //ADDED JAN 2012
 
+$Text['click_to_change'] = "Click to change!";
+$Text['cart_date'] = "Cart date";
+$Text['create_cart'] = "Crete Cart";
 
 /**
  *  Product categories

--- a/local_config/lang/es.php
+++ b/local_config/lang/es.php
@@ -485,6 +485,10 @@ $Text['msg_no_movements'] = "No hay movimientos para la cuenta y la fecha selecc
 $Text['msg_delete_incident'] = "¿Seguro que quieres eliminar este incidente?";
 //$Text['msg_err_selectFirstUF'] = "There is no household selected. Choose one first and then its purchases. No hay ninguna UF seleccionada.  Elige una primero y luego sus compras."; //ADDED JAN 2012
 
+$Text['click_to_change'] = "Clic par cambiar!";
+$Text['cart_date'] = "Fecha de la cesta";
+$Text['create_cart'] = "Crear Cesta";
+
 /**
  *  Product categories
  */
@@ -589,10 +593,10 @@ $Text['details'] = 'Detalles';
 $Text['actions'] = 'Acciones';
 $Text['incident_details'] = 'Detalles de Incidencias';
 $Text['distribution_level'] = 'Nivel de Distribución';
-$Text['internal_private'] = 'Internal (private)';
-$Text['internal_email_private'] = 'Internal + email (private)';
-$Text['internal_post'] = 'Internal + post to portal (public)';
-$Text['internal_email_post'] = 'Internal + email + post (public)';
+$Text['internal_private'] = 'Interno (privado)';
+$Text['internal_email_private'] = 'Interno + email (privado)';
+$Text['internal_post'] = 'Interno + Enviar al portal (público)';
+$Text['internal_email_post'] = 'Interno + email + Portal (público)';
 
 $Text['date'] = "Fecha";
 $Text['iva'] = "IVA";
@@ -689,7 +693,7 @@ $Text['no_results'] = "La búsqueda no ha producido resultados.";
 $Text['for'] = "para"; //as in order FOR Aurora
 $Text['date_for_order'] = "Fecha de entrega";
 $Text['finished_loading'] = "Carga Finalizada";
-$Text['msg_err_unrevised'] = "¡Hay items sin revisar en este pedido. Por favor, asegúrese de que todos los productos pedidos han llegado!";
+$Text['msg_err_unrevised'] = "¡Hay ítems sin revisar en este pedido. Por favor, asegúrese de que todos los productos pedidos han llegado!";
 $Text['btn_dis_anyway'] = "Distribuir igualmente";
 $Text['btn_remaining'] = "Revisar los pendientes";
 $Text['btn_disValitate'] = "Distribuye y valida";
@@ -726,7 +730,7 @@ $Text['btn_delete'] = "Borrar";
 $Text['wait_reset'] = "Por favor, espere mientras el pedido se reinicia...";
 $Text['msg_done'] = "Hecho!";
 $Text['msg_err_already_val'] = "Algunos o todos los ítems ya han sido validados! ¡¡Lo siento pero no es posible hacer mas cambios!!";
-$Text['print_several'] = "There is more than one order currently selected. Do you want to print them all in one go?";
+$Text['print_several'] = "Hay más de un pedido seleccionado. ¿Quieres imprimirlos todos?";
 $Text['btn_yes_all'] = "Sí, imprimir todo";
 $Text['btn_just_one'] = "No, solo uno";
 $Text['ostat_revised'] = "Revisado";

--- a/php/ctrl/Validate.php
+++ b/php/ctrl/Validate.php
@@ -46,8 +46,19 @@ try{
     	//this is the same as in /ctrl/Shop.php except the uf_id parameter which is flexible here
 	    case 'getShopCart':
   			printXML(stored_query_XML_fields('get_shop_cart', get_param('date',0), get_param('uf_id',0), get_param('cart_id',0),get_param('validated',0))); 
-			exit; 
-	    
+			exit;
+
+        case 'getShopCartHead':
+            $cart_id = get_param_int('cart_id', 0);
+            printXML(query_XML_fields(
+                "select id cart_id, ts_last_saved from aixada_cart
+                where ts_validated = 0 and id = {$cart_id}")); 
+            exit; 
+
+        case 'createEmptyCart':
+            echo create_empty_cart(get_param_int('uf_id'),get_param('date'));
+            exit;
+
 	  	case 'commit':
        		try {
 		  		$vm = new validation_cart_manager(get_session_user_id(), get_param('uf_id'), get_param('date')); 

--- a/php/utilities/shop_and_order.php
+++ b/php/utilities/shop_and_order.php
@@ -3,21 +3,20 @@
 require_once(__ROOT__ . 'php/inc/database.php');
 require_once(__ROOT__ . 'local_config/config.php');
 
+function create_empty_cart($uf_id, $date_for_shop) {
+    if (!$uf_id || !$date_for_shop) {
+        return 0;
+    }
+    $db = DBWrap::get_instance();
+    $db->Execute(
+        "insert into aixada_cart (
+            uf_id, date_for_shop
+        )
+        values (
+            {$uf_id}, '{$date_for_shop}'
+        );"
+    );
+    return $db->last_insert_id();
+}
 
-
-
-/*
-function get_active_ufs_or_account()
-{
-    global $Text;
-    $res = stored_query_XML('get_active_ufs', 'ufs', 'name');
-    $mant = '<ufs><row><id f="id">-2</id><name f="name"><![CDATA['
-        . $Text['consum_account'] 
-        . ']]></name></row>';
-    $ans = substr_replace($res, $mant, strpos($res, '<ufs>'), 5); 
-    return $ans;
-}*/
-
-
-	
 ?>

--- a/validate.php
+++ b/validate.php
@@ -106,6 +106,7 @@
 						return false;
 					}
 
+					$("#createCart").hide();
 					if (uf_id <=0) {
 						resetFields();
 						resetDeposit();
@@ -138,6 +139,49 @@
 			}); //end of listing
 
 
+            $("#crtDateForShop").datepicker({
+                dateFormat: 'DD d M, yy',
+                showAnim: '',
+                beforeShowDay: function(date){
+                    return [true, ""];
+                },
+                onSelect: function (dateText, instance){
+                    //refreshSelects($.getSelectedDate('#crtDateForShop'));
+                }
+            }).show();
+            $('.toggleShopDate').click(function(){
+                    $("#crtDateForShop").toggle();
+                });
+            var _today = new Date();
+            $("#crtDateForShop").datepicker('setDate', _today);
+            $("#btn_createCart").button().click(function() {
+                var _uf_id = $("#uf_cart_select option:selected").val(),
+                    _date_for_shop = $.getSelectedDate('#crtDateForShop');
+                $.ajax({
+                    type: "POST",
+                    url: "php/ctrl/Validate.php?oper=createEmptyCart&uf_id="+_uf_id+
+                            "&date="+_date_for_shop,
+                    success: function(msg) {
+                        $('#tbl_cart_listing tbody').xml2html('reload');
+                        $('#uf_cart_select').xml2html('reload',{
+                            url: 'php/ctrl/Validate.php',
+                            params: 'oper=getUFsCartCount',
+                            complete: function(rowCount){
+                                $('#uf_cart_select').val(_uf_id
+                                    ).attr('selected', true
+                                    ).trigger('change');
+                            }
+                        });
+                    },
+                    error: function(XMLHttpRequest, textStatus, errorThrown) {
+                        $.updateTips("#depositMsg", "error",
+                            XMLHttpRequest.responseText);
+                    },
+                    complete: function(msg) {
+                        $("#createCart").hide();
+                    }
+                });
+            });
 
 			//load purchase listing: how may carts does this uf have?
 			$('#tbl_Shop tbody').xml2html('init',{
@@ -158,8 +202,9 @@
 							$.showMsg({
 								msg:"<?php echo $Text['nothing_to_val'] ;?>",
 								type: 'warning'});
-								$('#cartLayer').aixadacart('resetCart');
-								//resetFields();
+							$('#cartLayer').aixadacart('resetCart');
+							$("#createCart").show();
+							//resetFields();
 
 						//one, should be today!
 						} else {
@@ -654,6 +699,7 @@
 				//the url to load the items for given uf/date
 				$('#cartLayer').aixadacart('loadCart',{
 					loadCartURL		: 'php/ctrl/Validate.php?oper=getShopCart&cart_id='+cart_id,
+					loadCartHeadURL: 'php/ctrl/Validate.php?oper=getShopCartHead&cart_id='+cart_id,
 					loadSuccess : function (){
 						$('#cartAnim').hide();
 						gActiveCart = true; 
@@ -711,12 +757,20 @@
 		    </div>
 		    <div id="titleRightCol">
 
-		    	<p class="textAlignRight">
+		    	<div class="textAlignRight">
 		    		<select id="uf_cart_select">
 		    			<option value="-10" selected="selected"><?php echo $Text['sel_uf']; ?></option>
 		    			<option value="{uf_id}" cc="{non_validated_carts}"> {uf_id} {uf_name}</option>
 		    		</select>
-		    	</p>
+		    		<div id="createCart" class="hidden">
+		    			<?=i18n("Fecha de la cesta")?>: <input type="text" 
+		    			    class="datePickerInput ui-widget-content ui-corner-all"
+		    			    id="crtDateForShop"
+		    			    title="<?=i18n("Click to edit")?>">
+		    			<button id="btn_createCart" 
+		    			    title="<?=i18n("Crear Cesta");?>"><?=i18n("Crear Cesta");?></button>
+		    		</div>
+		    	</div>
 		    </div>
 		</div>
 

--- a/validate.php
+++ b/validate.php
@@ -39,6 +39,10 @@
         $cfg_js_validate_deposit =
             (isset($cfg->validate_deposit) && !$cfg->validate_deposit) ?
             'false' : 'true'; // default true
+        $cfg_js_validate_btn_create_carts =
+            ( isset($cfg->validate_btn_create_carts) &&
+                    $cfg->validate_btn_create_carts ) ?
+            'true' : 'false'; // default false
     ?>
 	<script type="text/javascript">
 	$(function(){
@@ -55,6 +59,7 @@
 			var gTornUfId = <?=get_session_uf_id();?>;
 			var cfg_js_validate_self = <?php echo $cfg_js_validate_self; ?>;
 			var cfg_js_validate_deposit = <?php echo $cfg_js_validate_deposit; ?>;
+			var cfg_js_validate_btn_create_carts = <?php echo $cfg_js_validate_btn_create_carts; ?>;
 			var cfg_js_show_carts_filter = '<?php 
                 echo get_config('validate_show_carts','day')!=='week'? 
                     'today' : 
@@ -139,49 +144,51 @@
 			}); //end of listing
 
 
-            $("#crtDateForShop").datepicker({
-                dateFormat: 'DD d M, yy',
-                showAnim: '',
-                beforeShowDay: function(date){
-                    return [true, ""];
-                },
-                onSelect: function (dateText, instance){
-                    //refreshSelects($.getSelectedDate('#crtDateForShop'));
-                }
-            }).show();
-            $('.toggleShopDate').click(function(){
-                    $("#crtDateForShop").toggle();
-                });
-            var _today = new Date();
-            $("#crtDateForShop").datepicker('setDate', _today);
-            $("#btn_createCart").button().click(function() {
-                var _uf_id = $("#uf_cart_select option:selected").val(),
-                    _date_for_shop = $.getSelectedDate('#crtDateForShop');
-                $.ajax({
-                    type: "POST",
-                    url: "php/ctrl/Validate.php?oper=createEmptyCart&uf_id="+_uf_id+
-                            "&date="+_date_for_shop,
-                    success: function(msg) {
-                        $('#tbl_cart_listing tbody').xml2html('reload');
-                        $('#uf_cart_select').xml2html('reload',{
-                            url: 'php/ctrl/Validate.php',
-                            params: 'oper=getUFsCartCount',
-                            complete: function(rowCount){
-                                $('#uf_cart_select').val(_uf_id
-                                    ).attr('selected', true
-                                    ).trigger('change');
-                            }
-                        });
+            if (cfg_js_validate_btn_create_carts) {
+                $("#crtDateForShop").datepicker({
+                    dateFormat: 'DD d M, yy',
+                    showAnim: '',
+                    beforeShowDay: function(date){
+                        return [true, ""];
                     },
-                    error: function(XMLHttpRequest, textStatus, errorThrown) {
-                        $.updateTips("#depositMsg", "error",
-                            XMLHttpRequest.responseText);
-                    },
-                    complete: function(msg) {
-                        $("#createCart").hide();
+                    onSelect: function (dateText, instance){
+                        //refreshSelects($.getSelectedDate('#crtDateForShop'));
                     }
+                }).show();
+                $('.toggleShopDate').click(function(){
+                        $("#crtDateForShop").toggle();
+                    });
+                var _today = new Date();
+                $("#crtDateForShop").datepicker('setDate', _today);
+                $("#btn_createCart").button().click(function() {
+                    var _uf_id = $("#uf_cart_select option:selected").val(),
+                        _date_for_shop = $.getSelectedDate('#crtDateForShop');
+                    $.ajax({
+                        type: "POST",
+                        url: "php/ctrl/Validate.php?oper=createEmptyCart&uf_id="+_uf_id+
+                                "&date="+_date_for_shop,
+                        success: function(msg) {
+                            $('#tbl_cart_listing tbody').xml2html('reload');
+                            $('#uf_cart_select').xml2html('reload',{
+                                url: 'php/ctrl/Validate.php',
+                                params: 'oper=getUFsCartCount',
+                                complete: function(rowCount){
+                                    $('#uf_cart_select').val(_uf_id
+                                        ).attr('selected', true
+                                        ).trigger('change');
+                                }
+                            });
+                        },
+                        error: function(XMLHttpRequest, textStatus, errorThrown) {
+                            $.updateTips("#depositMsg", "error",
+                                XMLHttpRequest.responseText);
+                        },
+                        complete: function(msg) {
+                            $("#createCart").hide();
+                        }
+                    });
                 });
-            });
+            }
 
 			//load purchase listing: how may carts does this uf have?
 			$('#tbl_Shop tbody').xml2html('init',{
@@ -203,7 +210,9 @@
 								msg:"<?php echo $Text['nothing_to_val'] ;?>",
 								type: 'warning'});
 							$('#cartLayer').aixadacart('resetCart');
-							$("#createCart").show();
+                            if (cfg_js_validate_btn_create_carts) {
+                                $("#createCart").show();
+                            }
 							//resetFields();
 
 						//one, should be today!
@@ -763,12 +772,12 @@
 		    			<option value="{uf_id}" cc="{non_validated_carts}"> {uf_id} {uf_name}</option>
 		    		</select>
 		    		<div id="createCart" class="hidden">
-		    			<?=i18n("Fecha de la cesta")?>: <input type="text" 
+		    			<?=i18n('cart_date')?>: <input type="text" 
 		    			    class="datePickerInput ui-widget-content ui-corner-all"
 		    			    id="crtDateForShop"
-		    			    title="<?=i18n("Click to edit")?>">
+		    			    title="<?=i18n('click_to_change')?>">
 		    			<button id="btn_createCart" 
-		    			    title="<?=i18n("Crear Cesta");?>"><?=i18n("Crear Cesta");?></button>
+		    			    title="<?=i18n('create_cart');?>"><?=i18n('create_cart');?></button>
 		    		</div>
 		    	</div>
 		    </div>


### PR DESCRIPTION
Allows create a empty cart at validation. This is usefully to assign products to a UF with no orders and no shop or when is used the option `$order_distribution_method = 'distribute_and_validate'`.
If the config `validate_btn_create_carts` is true a button "Create cart" is displayed when is select a UF without  unvalidated carts.

NOTE: It also fixes the problem to add some products into an empty cart.