### PR TITLE
Option $development is still used.

### DIFF
--- a/local_config/config.php.sample
+++ b/local_config/config.php.sample
@@ -207,6 +207,11 @@ class configuration_vars {
     )
   );
   
+  /**
+   * Sets the global development variable for debugging etc. 
+   * 
+   */
+  public $development = true; 
   
     /**
    * the email address of the admin; used for sending out pwd changes


### PR DESCRIPTION
Used by: `php\inc\authentication.inc.php`  and `php\utilities\useruf.php`

The option `$development` is off by #186, sorry!