### PR TITLE
Fix small mismatch presentation of not closed a order in index.php.

### DIFF
--- a/index.php
+++ b/index.php
@@ -143,7 +143,7 @@
 						 $(row).children().eq(3).html("<p class='textAlignCenter'><?=$Text["not_yet_sent"];?></p>");		
 					} 
 
-					if (timeLeft <= 0){
+					if (timeLeft < 0){
 						$(row).children().eq(2).html('<span class="ui-icon ui-icon-locked tdIconCenter" title="order is closed"></span>');
 					}
 

--- a/sql/queries/aixada_queries_dates.sql
+++ b/sql/queries/aixada_queries_dates.sql
@@ -51,7 +51,7 @@ begin
 		aixada_provider pv,
 		aixada_product p
 	where
-		po.closing_date > today
+		po.closing_date >= today
 		and po.date_for_order <= until
 		and po.product_id = p.id
 		and p.provider_id = pv.id

--- a/sql/setup/aixada_queries_all.sql
+++ b/sql/setup/aixada_queries_all.sql
@@ -496,7 +496,7 @@ begin
 		aixada_provider pv,
 		aixada_product p
 	where
-		po.closing_date > today
+		po.closing_date >= today
 		and po.date_for_order <= until
 		and po.product_id = p.id
 		and p.provider_id = pv.id


### PR DESCRIPTION
Fix a small mismatch presentation on `index.php` that showed as `Closed` a order to close today. After this patch shows 0 as days to close instead of *"order is closed"*. Also show order to close today in *"Upcoming orders"* tab. (see similar issue on #176)