### PR TITLE
[PATCH] Remove extra space in email headers

### DIFF
--- a/php/utilities/general.php
+++ b/php/utilities/general.php
@@ -390,8 +390,8 @@ function send_mail($to, $subject, $bodyHTML, $options=null) {
         'From: '.$from."\r\n".
         'Reply-To: '.
             (isset($options['reply_to']) ? $options['reply_to'] : $from)."\r\n".
-        (isset($options['cc']) ? 'Cc :'.$options['cc']."\r\n" : '').
-        (isset($options['bcc']) ? 'Bcc :'.$options['bcc']."\r\n" : '').
+        (isset($options['cc']) ? 'Cc:'.$options['cc']."\r\n" : '').
+        (isset($options['bcc']) ? 'Bcc:'.$options['bcc']."\r\n" : '').
         'Return-Path: '.$from."\r\n".
         "X-Mailer: PHP\r\n".
         "MIME-Version: 1.0\r\n".


### PR DESCRIPTION
With this extra space, the malformed Cc or Bcc header was considered as the
first line of the body of the email, a new line was inserted before it. This
new line was preventing the following headers (including Content-Type) to be
interpreted as headers and the HTML email was displayed in plain text.
(text by ricola)

Reported by Josu in [Aixada-Dev](https://lists.riseup.net/www/info/aixada-dev) and tested by ricola.

Please merge, thanks.