### PR TITLE
The empty carts can cause errors to distribute and validate.

### DIFF
--- a/local_config/lang/ca-va.php
+++ b/local_config/lang/ca-va.php
@@ -701,6 +701,8 @@ $Text['msg_con_disValitate_prvInv'] =
     <li>i l'import de l'albarà s'anotarà al compte del proveïdor com a factura.</li>
     </ul>";
 $Text['msg_err_disValitate'] = "Error al distribuir i validar la comanda #";
+$Text['msg_err_disVal_nonEmpyCatrs'] = 
+    "Hi ha validacions pendents per a la data {date_for_shop}.<br>No és possible \"Distribuir i validar\" per a la mateixa data si hi ha validacions pendents!";
 $Text['btn_disValitate_ok'] = "Entesos: distribueix i valida!";
 $Text['btn_bakToRevise'] = "Encara no: vull seguir revisant";
 $Text['btn_disValitate_done'] = "Correcte!<br>La comanda #{order_id} ha estat distribuïda i validada.";

--- a/local_config/lang/en.php
+++ b/local_config/lang/en.php
@@ -709,6 +709,9 @@ $Text['msg_con_disValitate_prvInv'] =
     <li>and the total amount will be put as invoice to the provider account.</li>
     </ul>";
 $Text['msg_err_disValitate'] = "Error when distribute and validate order #";
+$Text['msg_err_disVal_nonEmpyCatrs'] = 
+    // Used to throw exception, multiple text lines causes a PHP warning "Header may not contain more than a single header..."
+    "There validations pending for {date_for_shop}.<br>Is not possible \"Distribute and validate\" for the same date if there are outstanding validations!";
 $Text['btn_disValitate_ok'] = "Understood: distributes and validates!";
 $Text['btn_bakToRevise'] = "Not yet: I want to continue reviewing";
 $Text['btn_disValitate_done'] = "Right!<br>Order #{order_id} has been distributed and validated.";

--- a/local_config/lang/es.php
+++ b/local_config/lang/es.php
@@ -710,6 +710,8 @@ $Text['msg_con_disValitate_prvInv'] =
     <li>y el importe del albarán se anotará en la cuenta del proveedor como factura.</li>
     </ul>";
 $Text['msg_err_disValitate'] = "Error al distribuir y validar el pedido #";
+$Text['msg_err_disVal_nonEmpyCatrs'] =
+    "Hay validaciones pendientes para la fecha {date_for_shop}.<br>No es posible \"Distribuir y validar\" para la misma fecha si hay validaciones pendientes!";
 $Text['btn_disValitate_ok'] = "Entendidos: distribuye y valida!";
 $Text['btn_bakToRevise'] = "Todavía no: quiero seguir revisando";
 $Text['btn_disValitate_done'] = "Correcto!<br>El pedido #{order_id} ha sido distribuido y validado.";

--- a/php/utilities/orders.php
+++ b/php/utilities/orders.php
@@ -394,15 +394,29 @@ function directly_validate_order($order_id, $record_provider_invoice) {
     prepare_order_to_shop(get_param_int('order_id'));
     $db = DBWrap::get_instance();
     try {
-        $db->start_transaction();
         
-        // Set date for shop as date for order
+        // Check date for shop non empty carts.
         $row_or = get_row_query(
             "select provider_id, date_for_order 
             from aixada_order where id = {$order_id};");
         $date_for_shop = $row_or['date_for_order'];
         $provider_id = $row_or['provider_id'];
+        $carts_for_date = get_row_query(
+            "select c.id
+            from aixada_cart c 
+            inner join aixada_shop_item si on si.cart_id = c.id
+            where c.date_for_shop = '{$date_for_shop}' and c.ts_validated = 0
+            limit 1;"
+        );
+        if ($carts_for_date) {
+            throw new Exception(i18n(
+                'msg_err_disVal_nonEmpyCatrs',
+                array('date_for_shop'=>$date_for_shop)
+            ));
+        }
         
+        // Set date for shop as date for order
+        $db->start_transaction();
         $operator_id = get_session_user_id();
         //For each uf
         $rs = $db->Execute("select distinct os.uf_id
@@ -411,15 +425,30 @@ function directly_validate_order($order_id, $record_provider_invoice) {
         while ($row = $rs->fetch_assoc()) {
             $uf_id = $row['uf_id'];
             // Create cart
-            $db->Execute(
-                "insert into aixada_cart (
-                    uf_id, date_for_shop
-                )
-                values (
-                    {$uf_id}, '{$date_for_shop}'
-                );"
+            $cart_for_date = get_row_query(
+                "select c.id
+                from aixada_cart c
+                left join aixada_shop_item si on si.cart_id = c.id
+                where 
+                    si.cart_id is null 
+                    and c.uf_id = {$uf_id}
+                    and c.date_for_shop = '{$date_for_shop}'
+                    and c.ts_validated = 0
+                limit 1;"
             );
-            $cart_id = $db->last_insert_id();
+            if ($cart_for_date) {
+                $cart_id = $cart_for_date['id'];
+            } else {
+                $db->Execute(
+                    "insert into aixada_cart (
+                        uf_id, date_for_shop
+                    )
+                    values (
+                        {$uf_id}, '{$date_for_shop}'
+                    );"
+                );
+                $cart_id = $db->last_insert_id();
+            }
             // Copy revised items into aixada_shop_item with to corresponding cart
             $db->Execute(
                 "insert into aixada_shop_item (


### PR DESCRIPTION
The empty carts are reused for the same date, and also warns and cancel if there are pending validate products carts.