### PR TITLE
The controller should check the order status.

### DIFF
--- a/php/ctrl/Orders.php
+++ b/php/ctrl/Orders.php
@@ -76,6 +76,7 @@ try{
     		
     	//set the global revisio status of the order
     	case 'setOrderStatus':
+    		chk_no_validate_order(get_param_int('order_id', 0));
     		echo do_stored_query('set_order_status', get_param('order_id'), get_param('status')  );
     		exit; 
     		
@@ -92,7 +93,9 @@ try{
     		
 		//moves an order from revision to shop_item (into people's cart for the given date) 
     	case 'moveOrderToShop':
-			prepare_order_to_shop(get_param_int('order_id'));
+    		$order_id = get_param_int('order_id', 0);
+    		chk_no_validate_order($order_id);
+    		prepare_order_to_shop($order_id);
     		echo do_stored_query('move_order_to_shop', get_param('order_id'), get_param('date'));
     		exit;
             

--- a/php/utilities/orders.php
+++ b/php/utilities/orders.php
@@ -307,9 +307,22 @@ function finalize_order($provider_id, $date_for_order)
 	
 	
 	//check here if an order_id already exists for this date and provider. 
+    if (!get_row_query(
+        "select oi.id
+        from 
+            aixada_order_item oi,
+            aixada_product p
+        where
+            oi.date_for_order = '{$date_for_order}'
+            and oi.order_id is null -- so, order is not closed
+            and oi.product_id = p.id
+            and p.provider_id = {$provider_id};")
+    ) { // No open orders for this date
+        throw new Exception ($Text['ostat_closed']);
+    }
 	
 	
-	
+	// Send eMail to provider
 	if ($config_vars->internet_connection && $config_vars->email_orders){
 		
         $provider_name = get_list_query(array(
@@ -386,11 +399,27 @@ function finalize_order($provider_id, $date_for_order)
 }
 
 /**
+ * Check no validated carts for this order. Throw error if exist a validated cart
+ * @param integer $order_id
+ */
+function chk_no_validate_order($order_id) {
+    $rs = do_stored_query('get_validated_status',$order_id, 0);
+    $row = $rs->fetch_array();
+    $db = DBWrap::get_instance();
+    $db->free_next_results();
+    if ($row) {
+        throw new Exception(i18n('msg_err_already_val'));
+    }
+}
+
+/**
  * Distribute and directly validate an order
  * @param integer $order_id
  */
 function directly_validate_order($order_id, $record_provider_invoice) {
+    chk_no_validate_order($order_id);
     
+    // Ok, do it
     prepare_order_to_shop(get_param_int('order_id'));
     $db = DBWrap::get_instance();
     try {

--- a/sql/queries/aixada_queries_products.sql
+++ b/sql/queries/aixada_queries_products.sql
@@ -503,7 +503,7 @@ begin
 		po.closing_date,
 		datediff(po.closing_date, today) as time_left,
 		(select
-			o.id
+			max(o.id) -- This prevent error: "Subquery returns more than 1 row"
 		 from
 		 	aixada_order o,
 		 	aixada_product pp

--- a/sql/setup/aixada_queries_all.sql
+++ b/sql/setup/aixada_queries_all.sql
@@ -2281,7 +2281,7 @@ begin
 		po.closing_date,
 		datediff(po.closing_date, today) as time_left,
 		(select
-			o.id
+			max(o.id) -- This prevent error: "Subquery returns more than 1 row"
 		 from
 		 	aixada_order o,
 		 	aixada_product pp


### PR DESCRIPTION
`manage_orders.php` allows close an order if it is open when the list orders is displayed. But what happens if another user has closed the order after displaying the list? Yes... the order will be closed twice, and activating provider products fail!

This patch proposes some controls on the server to prevent actions on orders that no longer have the state shown in the list or in the distribute page.