### PR TITLE
Cumulative order: fix to uses final price.

### DIFF
--- a/sql/queries/aixada_queries_products.sql
+++ b/sql/queries/aixada_queries_products.sql
@@ -693,9 +693,7 @@ begin
         u.unit,
    		round((p.unit_price * (1 + iva.percent/100) * (1 + r.rev_tax_percent/100)),2) as unit_price,
 		iva.percent as iva_percent,
-   		r.rev_tax_percent,
-        p.unit_price
-        
+   		r.rev_tax_percent
    from 
 	   	aixada_product p,
 	   	aixada_provider pv,

--- a/sql/setup/aixada_queries_all.sql
+++ b/sql/setup/aixada_queries_all.sql
@@ -2471,9 +2471,7 @@ begin
         u.unit,
    		round((p.unit_price * (1 + iva.percent/100) * (1 + r.rev_tax_percent/100)),2) as unit_price,
 		iva.percent as iva_percent,
-   		r.rev_tax_percent,
-        p.unit_price
-        
+   		r.rev_tax_percent
    from 
 	   	aixada_product p,
 	   	aixada_provider pv,


### PR DESCRIPTION
Current sql procedure `get_preorderable_products` returns two columns `unit_price` and the last column is without VAT and Rev.Tax. This erroneous column is used by `shop_and_order.php`.