### PR TITLE
On new order should check if order is already closed.

### DIFF
--- a/local_config/lang/ca-va.php
+++ b/local_config/lang/ca-va.php
@@ -886,6 +886,8 @@ $Text['msg_err_delorerable'] = "Ja s'han demanat productes per aquesta data. No 
 $Text['msg_pre2Order'] = "Converteix aquesta comanda acumulativa a comanda normal. Pots triar una data d'entrega";
 
 $Text['msg_err_modified_order'] = "Algú ha modificat els productes a demanar per la data actual. Alguns productes que havies demanat ja no estan disponibles i desapareixeran del teu carret una vegada recarregat.";
+$Text['msg_err_modif_order_closed'] = "S'ha intentat modificar alguna comanda que ja està tancada.";
+$Text['msg_err_cart_reloaded'] = "La seva cistella es mostrarà de nou.";
 $Text['btn_confirm_del'] = "Esborrar! Estic segur";
 $Text['print_new_win'] = "Nova finestra";
 $Text['print_pdf'] = "Descarregar pdf";

--- a/local_config/lang/en.php
+++ b/local_config/lang/en.php
@@ -894,6 +894,8 @@ $Text['msg_err_delorerable'] = "Items have been ordered for this product and dat
 $Text['msg_pre2Order'] = "Convert this preorder to a regular order. This will assign an order date, i.e. when the expected items will arrive.";
 
 $Text['msg_err_modified_order'] = "Orderable products have been deactivated for the current date while you were ordering. Some products that you already had ordered are no longer available and will disappear from your cart after it has been reloaded.";
+$Text['msg_err_modif_order_closed'] = "Attempt to modify an order closed.";
+$Text['msg_err_cart_reloaded'] = "Your cart will be reloaded.";
 $Text['btn_confirm_del'] = "Delete anyway!!";
 $Text['print_new_win'] = "New window";
 $Text['print_pdf'] = "Download pdf";

--- a/local_config/lang/es.php
+++ b/local_config/lang/es.php
@@ -895,6 +895,8 @@ $Text['msg_err_delorerable'] = "Existe un pedido para este producto y fecha. No 
 $Text['msg_pre2Order'] = "Convierte el pedido acumulativo en un pedido regular. Se crea una fecha de entrega. ";
 
 $Text['msg_err_modified_order'] = "Alguien ha modificado los productos a pedir para fecha actual. Algunos productos que habías pedido ya no están disponibles y desaparecerán de tu carrito una vez recargado.";
+$Text['msg_err_modif_order_closed'] = "Se ha intentado modificar algún pedido que ya está cerrado.";
+$Text['msg_err_cart_reloaded'] = "Su cesta se mostrará de nuevo.";
 $Text['btn_confirm_del'] = "Sí, eliminar!!";
 $Text['print_new_win'] = "Ventana nueva";
 $Text['print_pdf'] = "Descarga pdf";

--- a/php/lib/order_cart_manager.php
+++ b/php/lib/order_cart_manager.php
@@ -48,7 +48,7 @@ class order_cart_manager extends abstract_cart_manager {
 	
 	//which of the order items pertain to a closed order. 
 	protected $_closed_orders = array(); 
-
+	protected $tried_modif_closed = false;
 	
 	
     /**
@@ -66,7 +66,18 @@ class order_cart_manager extends abstract_cart_manager {
         parent::__construct($uf_id, $date_for_order); 
     }
 
-	/**
+    public function commit($arrQuant, $arrProdId, $arrIva, $arrRevTax, $arrOrderItemId, $cart_id, $last_saved, $arrPreOrder, $arrPrice) 
+    {
+	    $this->tried_modif_closed = false;
+        // call the super-class
+        $res = parent::commit($arrQuant, $arrProdId, $arrIva, $arrRevTax, $arrOrderItemId, $cart_id, $last_saved, $arrPreOrder, $arrPrice);
+        if (true || $this->tried_modif_closed) {
+            throw new Exception(i18n('msg_err_modif_order_closed'));
+        }
+        return $res;
+    }
+
+    /**
 	 * Overload function of _make_rows of abstract cart manager. 
 	 * 
 	 * @param array $arrQuant quantity of product bought
@@ -85,8 +96,10 @@ class order_cart_manager extends abstract_cart_manager {
     	     	
     	$db = DBWrap::get_instance();
     	
+    	$open_orders = array();
     	//make sure we don't have an empty cart (when deleting all items from order)
     	if (count($arrProdId) > 0){
+	    	$listProdId = implode(",", $arrProdId);
 	    	//get already closed orders for the current date and this uf. 
 	    	//closed orders cannot be update anymore
 	    	$sql = "select
@@ -95,13 +108,8 @@ class order_cart_manager extends abstract_cart_manager {
 	    				aixada_order_item oi
 	    			where
 	    				oi.date_for_order ='". $this->_date."'
-	    				and oi.product_id in (";
-	    	
-			    	foreach ($arrProdId as $id){
-			    		$sql .= $id . ",";
-					}		
-			
-				$sql = rtrim($sql, ",") .") and oi.uf_id=".$this->_uf_id." and oi.order_id > 0;";
+	    				and oi.product_id in (". $listProdId .")
+	    				and oi.uf_id=".$this->_uf_id." and oi.order_id > 0;";
 
 			$rs = $db->Execute($sql);	
 	       	
@@ -109,26 +117,59 @@ class order_cart_manager extends abstract_cart_manager {
 	    		array_push($this->_closed_orders, $row['product_id']); 
 	    	}
 	       	$db->free_next_results();
+            
+            // Get open products on date for order
+            $sql = "select 
+                        po.product_id
+                    from 
+                        aixada_product_orderable_for_date po
+                    where
+                        po.closing_date >= '" . date('Y-m-d') . "'
+                        and po.date_for_order = '{$this->_date}'
+                        and po.product_id in ({$listProdId})";
+            $rs = $db->Execute($sql);
+            while ($row = $rs->fetch_array()){
+                array_push($open_orders, $row['product_id']); 
+            }
+            $db->free_next_results();
     	}	
     	
     	
+        $tried_modif_closed = false;
         for ($i=0; $i < count($arrQuant); ++$i) {
             if ($arrPreOrder[$i] == 'false'){
             	
             	//if product id exists in closed orders, don't update it. 
             	$closed = array_search($arrProdId[$i], $this->_closed_orders);
-
-            	if ($closed === false){
+            	//if order is closed don't add a product. 
+            	$opened = array_search($arrProdId[$i], $open_orders) !== false;
+            	if ($closed === false && $opened === true){
 	                $this->_rows[] = new order_item($this->_date,
 	                                                $this->_uf_id,
 	                                                $arrProdId[$i], 
 	                                                $arrQuant[$i],  
 	                                                $this->_cart_id, 
 	                                                $arrPrice[$i]);
-            	}
-            } 
-                                                
+            	} elseif (!$tried_modif_closed){
+                // verify if closed order exist and quantity is the same
+                    $sql = "select
+                        oi.product_id
+                    from 
+                        aixada_order_item oi
+                    where
+                        oi.date_for_order = '{$this->_date}'
+                        and oi.product_id = {$arrProdId[$i]}
+                        and oi.uf_id = {$this->_uf_id}
+                        and oi.quantity = {$arrQuant[$i]}
+                        and oi.order_id is not null;";
+                    if (!get_row_query($sql)) {
+                    // oops! tried to modify/add on a closed order
+                        $tried_modif_closed = true;
+                    }
+                }
+            }
         }
+        $this->tried_modif_closed = $tried_modif_closed;
     }
     
     

--- a/shop_and_order.php
+++ b/shop_and_order.php
@@ -79,7 +79,8 @@
 			} else {
 
 				$.showMsg({
-					msg:err_msg + " Your cart will be reloaded.",
+					msg: err_msg +
+						"<br><span style=\"color:black\"><?=$Text['msg_err_cart_reloaded'];?></span>",
 					buttons: {
 						"<?=$Text['btn_ok'];?>":function(){
 


### PR DESCRIPTION
"shop_and_order.php" allows add products when no exist a open date for order.

As to reproduce:
 * Begin an order.
 * Close the order in another browser.
 * Add a product, oops! tells us that it has been successfully saved!!
   * but luckily!, the product is not added.
   * a new open order exist but we can't even see or close.
 * If we modify existing quantities also tells us that it has been successfully saved!!
   * but luckily!, not is true!

This patch aims to prevent add products when closed date. And also notify to the user that their data has not been saved.