### PR TITLE
 Use ajaxQueue to work on hosting with few resources.

### DIFF
--- a/CHANGELOG-es.md
+++ b/CHANGELOG-es.md
@@ -92,6 +92,8 @@ Ahora también se puede desactivar la compra directa, permitir validarse a uno m
   * Permitit el uso de servidores SMTP (:bulb:`config.php`: `$email_SMTP_host`).
 * Mejoras en soporte de plataformas diversas, servidores Windows, MariaDB, versiones de PHP >= 5.3...
  (entre otros #184)
+  * Para trabajar en hostings con pocos recursos se recomientda sequenciar ajax
+    (:bulb:`config.php`: `$use_ajaxQueue`).
 * La página report_stock muestra en valor total del stock de productos y adiciones/correcciones.
 * En la página proveedor/producto ahora se puede filtrar por descripción de los productos.
 * Exportación rudimentaria de pedido a csv

--- a/activate_all_roles.php
+++ b/activate_all_roles.php
@@ -11,10 +11,7 @@
 	
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
    
 	<script type="text/javascript">
 	$(function(){

--- a/activate_roles.php
+++ b/activate_roles.php
@@ -11,10 +11,7 @@
     
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
    		
  	<script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>
      

--- a/incidents.php
+++ b/incidents.php
@@ -12,10 +12,7 @@
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
    
 	<script type="text/javascript">
 

--- a/index.php
+++ b/index.php
@@ -23,10 +23,7 @@
     
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
     <script type="text/javascript" src="js/aixadacart/jquery.aixadacart.js?v=20170108" ></script>
      
    	<script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script> 

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@
 
  	<link rel="stylesheet" type="text/css"   media="screen" href="css/aixada_main.css" />
   	<link rel="stylesheet" type="text/css"   media="print"  href="css/print.css" />
-  	<link rel="stylesheet" type="text/css"   media="screen" href="js/aixadacart/aixadacart.css?v=20170108" />
+  	<link rel="stylesheet" type="text/css"   media="screen" href="js/aixadacart/aixadacart.css?v=<?=aixada_js_version();?>" />
   	<link rel="stylesheet" type="text/css"   media="screen" href="js/fgmenu/fg.menu.css"   />
     <link rel="stylesheet" type="text/css"   media="screen" href="css/ui-themes/<?=$default_theme;?>/jqueryui.css"/>
      
@@ -24,10 +24,10 @@
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
     <?php echo aixada_js_src(); ?>
-    <script type="text/javascript" src="js/aixadacart/jquery.aixadacart.js?v=20170108" ></script>
+    <script type="text/javascript" src="js/aixadacart/jquery.aixadacart.js?v=<?=aixada_js_version();?>" ></script>
+    <script type="text/javascript" src="js/aixadacart/i18n/cart.locale-<?=$language;?>.js?v=<?=aixada_js_version();?>" ></script>
      
    	<script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script> 
-    <script type="text/javascript" src="js/aixadacart/i18n/cart.locale-<?=$language;?>.js" ></script>
 	   
 	<script type="text/javascript">
 	$(function(){

--- a/js/aixadautilities/jquery.aixadaMenu.js
+++ b/js/aixadautilities/jquery.aixadaMenu.js
@@ -52,7 +52,7 @@ $(function(){
 	$('#role_select').change(function (){
    		var new_role = $("#role_select option:selected").val(); 
 		var rq_uri = window.location;
-   		$.ajax({
+   		$.ajaxQueue({
    			type: "POST",
             url: "php/ctrl/Cookie.php?change_role_to=" + new_role + "&originating_uri=" + rq_uri,
             dataType: "xml",
@@ -68,7 +68,7 @@ $(function(){
 	
 	//function to retrieve menu access rights
 	if (typeof(role) == "string" ){
-		$.ajax({
+		$.ajaxQueue({
 			type: "POST",
 	            url: "php/ctrl/SmallQ.php?oper=configMenu&user_role="+role,
 	            dataType: "xml", 
@@ -85,7 +85,7 @@ $(function(){
 	$('#lang_select').change(function (){
    		var new_lang = $("#lang_select option:selected").val(); 
 		var rq_uri = window.location;
-   		$.ajax({
+   		$.ajaxQueue({
    			type: "POST",
             url: "php/ctrl/Cookie.php?change_lang_to=" + new_lang + "&originating_uri=" + rq_uri,
             dataType: "xml",
@@ -98,7 +98,7 @@ $(function(){
 	
 	$('#logoutRef').click(function(e){
 		
-		 $.ajax({
+		 $.ajaxQueue({
 			type: 'POST',
 			url: 'php/ctrl/Login.php?oper=logout',
 			success : function(msg){

--- a/js/aixadautilities/jquery.aixadaUtilities.js
+++ b/js/aixadautilities/jquery.aixadaUtilities.js
@@ -131,7 +131,7 @@ $(function(){
 	
 	$.extend({
 		getAixadaDates : function(oper, callbackfn){
-			$.ajax({
+			$.ajaxQueue({
 				type: "POST",
 				url: "php/ctrl/Dates.php?oper="+oper+"&responseFormat=array",		
 				dataType: "JSON", 
@@ -147,7 +147,7 @@ $(function(){
 						type: 'error'});
 					
 				}		
-			}); //end ajax retrieve date
+			}); //end retrieve date
 			
 		},
 		//util function to retrieve formated date from datepicker

--- a/js/aixadautilities/jquery.aixadaXML2HTML.js
+++ b/js/aixadautilities/jquery.aixadaXML2HTML.js
@@ -133,7 +133,7 @@
 				    	var rowName =  $this.data('xml2html').rowName;
 	    	
 				    	//load the initial list
-				    	$.ajax({
+				    	$.ajaxQueue({
 									type: type,
 									url: url + "?" + params,		
 									dataType: "xml", 
@@ -170,7 +170,7 @@
 	  							   complete : function(msg){
 	  							 	
 	  							    }
-						});	//end ajax
+						});	//end
 				    	
 				    	
 				    	

--- a/js/jquery-ajaxQueue/README.md
+++ b/js/jquery-ajaxQueue/README.md
@@ -1,0 +1,1 @@
+Module obtained from: [github.com/gnarf/jquery-ajaxQueue](https://github.com/gnarf/jquery-ajaxQueue)

--- a/js/jquery-ajaxQueue/jQuery.ajaxQueue.js
+++ b/js/jquery-ajaxQueue/jQuery.ajaxQueue.js
@@ -1,0 +1,46 @@
+(function($) {
+
+// jQuery on an empty object, we are going to use this as our Queue
+var ajaxQueue = $({});
+
+$.ajaxQueue = function( ajaxOpts ) {
+    var jqXHR,
+        dfd = $.Deferred(),
+        promise = dfd.promise();
+
+    // run the actual query
+    function doRequest( next ) {
+        jqXHR = $.ajax( ajaxOpts );
+        jqXHR.done( dfd.resolve )
+            .fail( dfd.reject )
+            .then( next, next );
+    }
+
+    // queue our ajax request
+    ajaxQueue.queue( doRequest );
+
+    // add the abort method
+    promise.abort = function( statusText ) {
+
+        // proxy abort to the jqXHR if it is active
+        if ( jqXHR ) {
+            return jqXHR.abort( statusText );
+        }
+
+        // if there wasn't already a jqXHR we need to remove from queue
+        var queue = ajaxQueue.queue(),
+            index = $.inArray( doRequest, queue );
+
+        if ( index > -1 ) {
+            queue.splice( index, 1 );
+        }
+
+        // and then reject the deferred
+        dfd.rejectWith( ajaxOpts.context || ajaxOpts, [ promise, statusText, "" ] );
+        return promise;
+    };
+
+    return promise;
+};
+
+})(jQuery);

--- a/js/jquery-ajaxQueue/jQuery.ajaxQueueNo.js
+++ b/js/jquery-ajaxQueue/jQuery.ajaxQueueNo.js
@@ -1,0 +1,2 @@
+// Don't use ajaxQueue
+jQuery.ajaxQueue = jQuery.ajax;

--- a/local_config/config.php.sample
+++ b/local_config/config.php.sample
@@ -214,6 +214,12 @@ class configuration_vars {
   public $development = true; 
   
   /**
+   * To work on hostings with few resources (memory) it is recommended to
+   * sequence ajax requests, this avoids simulating requests from a page.
+   */
+  //public $use_ajaxQueue  = true; 
+  
+    /**
    * the email address of the admin; used for sending out pwd changes
    * and orders. 
    */

--- a/login.php
+++ b/login.php
@@ -1,19 +1,7 @@
 <?php
+require_once("php/inc/header.inc.base.php");
 
-
-define('DS', DIRECTORY_SEPARATOR);
-define('__ROOT__', dirname(__FILE__).DS); 
-
-require_once(__ROOT__ . 'php'.DS.'inc'.DS.'cookie.inc.php');
 require_once(__ROOT__ . 'php'.DS.'inc'.DS.'authentication.inc.php');
-require_once(__ROOT__ . 'php'.DS.'lib'.DS.'exceptions.php');
-require_once(__ROOT__ . 'local_config'.DS.'config.php');
-require_once(__ROOT__ . 'php'.DS.'utilities'.DS.'general.php');
-
-
-$default_theme = get_session_theme();
-$language = get_session_language();
-require_once(__ROOT__ . 'local_config'.DS.'lang'.DS.'' . $language  . '.php');
 
 // This controls if the table_manager objects are stored in $_SESSION or not.
 // It looks like doing it cuts down considerably on execution time.

--- a/login.php
+++ b/login.php
@@ -36,8 +36,7 @@ if (!isset($_SESSION)) {
    
 	<script type="text/javascript" src="js/jquery/jquery.js"></script>
 	<script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>	
+	<?php echo aixada_js_src(false); ?>	
    	
     <style><?php
         $login_header_image =

--- a/make_canned_responses.php
+++ b/make_canned_responses.php
@@ -204,5 +204,7 @@ make_canned_responses();
 
 write_file('sql/queries/canned_queries.sql', make_canned_queries());
 
-
-?>
+write_file(
+    'php/inc/header.inc.version.php',
+    "\$aixada_vesion_lastDate = '" . date('Ymd_His') . "';\n"
+);

--- a/manage_admin.php
+++ b/manage_admin.php
@@ -12,10 +12,7 @@
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
    
 	<?php 
         $backup_method = get_config('db_backup_method','');

--- a/manage_data.php
+++ b/manage_data.php
@@ -66,10 +66,7 @@
     <script type="text/javascript" src="js/jqGrid-4.3.1/js/jquery.jqGrid.min.js"></script>
     
 	<script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-	<script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-   	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+	<?php echo aixada_js_src(); ?>
     
     <style>
         .ui-state-highlight, 

--- a/manage_import.php
+++ b/manage_import.php
@@ -14,8 +14,7 @@
 
     <script type="text/javascript" src="js/jquery/jquery-1.9.0.js"></script>
     <script type="text/javascript" src="js/jqueryui/jquery-ui-1.10.0.custom.min.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(false); ?>
 
     <script src="js/jquery-fileupload/js/jquery.iframe-transport.js"></script>
     <script src="js/jquery-fileupload/js/jquery.fileupload.js"></script>

--- a/manage_money.php
+++ b/manage_money.php
@@ -58,10 +58,7 @@
 	
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
 
 <?php
 // Generate html to use in the form.

--- a/manage_mysettings.php
+++ b/manage_mysettings.php
@@ -11,10 +11,7 @@
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
    
 	<script type="text/javascript">
 	

--- a/manage_orderable_products.php
+++ b/manage_orderable_products.php
@@ -11,10 +11,7 @@
     
     <script type="text/javascript" src="js/jquery/jquery.js"></script>	    
 	<script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-	<script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-   	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-   	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+	<?php echo aixada_js_src(); ?>
  	<script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>   
     
    

--- a/manage_orders.php
+++ b/manage_orders.php
@@ -34,10 +34,8 @@
     
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
+    
     <script type="text/javascript" src="js/tablesorter/jquery.tablesorter.js" ></script>
     <script type="text/javascript" src="js/jeditable/jquery.jeditable.mini.js" ></script>
     <script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>

--- a/manage_providers.php
+++ b/manage_providers.php
@@ -12,10 +12,7 @@
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
     <script type="text/javascript" src="js/aixadautilities/jquery.aixadaExport.js" ></script>
     <script type="text/javascript" src="js/tablesorter/jquery.tablesorter.js" ></script>
  	

--- a/manage_stock.php
+++ b/manage_stock.php
@@ -12,10 +12,7 @@
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
     
  	<script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>
  		

--- a/manage_ufmember.php
+++ b/manage_ufmember.php
@@ -12,10 +12,7 @@
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
     <script type="text/javascript" src="js/aixadautilities/jquery.aixadaExport.js" ></script>
    
 	<script type="text/javascript">

--- a/php/inc/header.inc.base.php
+++ b/php/inc/header.inc.base.php
@@ -1,0 +1,42 @@
+<?php 
+
+define('DS', DIRECTORY_SEPARATOR);
+define('__ROOT__', dirname(dirname(dirname(__FILE__))).DS); 
+
+require_once("header.inc.version.php"); // To obtain: $aixada_vesion_lastDate
+require_once(__ROOT__ . 'php'.DS.'inc'.DS.'cookie.inc.php');
+//require_once(__ROOT__ . 'php'.DS.'lib'.DS.'exceptions.php'); Is required by 'cookie.inc.php'
+require_once(__ROOT__ . 'local_config'.DS.'config.php');
+require_once(__ROOT__ . 'php'.DS.'utilities'.DS.'general.php');
+
+//$dev = configuration_vars::get_instance()->development;
+$language = get_session_language(); 
+$default_theme = get_session_theme();
+
+require_once(__ROOT__ . 'local_config'.DS.'lang'.DS. get_session_language() . '.php');
+
+// To declare common JavaScript sources used by a Aixada page.
+function aixada_js_version() {
+    global $aixada_vesion_lastDate;
+    return $aixada_vesion_lastDate;
+}
+function aixada_js_src($useMenus = true) {
+    global $aixada_vesion_lastDate;
+    $src = "<!-- aixada_js_src -->";
+    if ($useMenus) {
+        $src .= "
+            <script src=\"js/fgmenu/fg.menu.js?v={$aixada_vesion_lastDate}\"></script>
+            <script src=\"js/aixadautilities/jquery.aixadaMenu.js?v={$aixada_vesion_lastDate}\"></script>";
+    }
+    $src .= "
+        <script src=\"js/aixadautilities/jquery.aixadaXML2HTML.js?v={$aixada_vesion_lastDate}\"></script>
+        <script src=\"js/aixadautilities/jquery.aixadaUtilities.js?v={$aixada_vesion_lastDate}\"></script>";
+    if (get_config('use_ajaxQueue')) {
+        $src .= "
+            <script src=\"js/jquery-ajaxQueue/jQuery.ajaxQueue.js?v={$aixada_vesion_lastDate}\"></script>";
+    } else {
+        $src .= "
+            <script src=\"js/jquery-ajaxQueue/jQuery.ajaxQueueNo.js?v={$aixada_vesion_lastDate}\"></script>";
+    }
+    return $src . "\n";
+}

--- a/php/inc/header.inc.base.php
+++ b/php/inc/header.inc.base.php
@@ -1,7 +1,8 @@
 <?php 
-
-define('DS', DIRECTORY_SEPARATOR);
-define('__ROOT__', dirname(dirname(dirname(__FILE__))).DS); 
+if (!defined('__ROOT__')) {
+    define('DS', DIRECTORY_SEPARATOR);
+    define('__ROOT__', dirname(dirname(dirname(__FILE__))).DS); 
+}
 
 require_once("header.inc.version.php"); // To obtain: $aixada_vesion_lastDate
 require_once(__ROOT__ . 'php'.DS.'inc'.DS.'cookie.inc.php');

--- a/php/inc/header.inc.php
+++ b/php/inc/header.inc.php
@@ -22,6 +22,10 @@ require_once(__ROOT__ . 'local_config'.DS.'lang'.DS. get_session_language() . '.
 $language = get_session_language(); 
 
 // To declare common JavaScript sources used by a Aixada page.
+function aixada_js_version() {
+    global $aixada_vesion_lastDate;
+    return $aixada_vesion_lastDate;
+}
 function aixada_js_src($useMenus = true) {
     global $aixada_vesion_lastDate;
     $src = "<!-- aixada_js_src -->";

--- a/php/inc/header.inc.php
+++ b/php/inc/header.inc.php
@@ -1,5 +1,7 @@
 <?php 
-require_once("php/inc/header.inc.base.php");
+define('DS', DIRECTORY_SEPARATOR);
+define('__ROOT__', dirname(dirname(dirname(__FILE__))).DS);
+require_once(__ROOT__ . "/php/inc/header.inc.base.php");
 
 $tpl_print_orders = configuration_vars::get_instance()->print_order_template;
 $tpl_print_myorders = configuration_vars::get_instance()->print_my_orders_template;

--- a/php/inc/header.inc.php
+++ b/php/inc/header.inc.php
@@ -3,6 +3,7 @@
 define('DS', DIRECTORY_SEPARATOR);
 define('__ROOT__', dirname(dirname(dirname(__FILE__))).DS); 
 
+require_once("header.inc.version.php"); // To obtain: $aixada_vesion_lastDate
 require_once(__ROOT__ . 'php'.DS.'inc'.DS.'cookie.inc.php');
 require_once(__ROOT__ . 'local_config'.DS.'config.php');
 require_once(__ROOT__ . 'php'.DS.'utilities'.DS.'general.php');
@@ -19,6 +20,28 @@ $tpl_print_incidents = configuration_vars::get_instance()->print_incidents_templ
 
 require_once(__ROOT__ . 'local_config'.DS.'lang'.DS. get_session_language() . '.php');
 $language = get_session_language(); 
+
+// To declare common JavaScript sources used by a Aixada page.
+function aixada_js_src($useMenus = true) {
+    global $aixada_vesion_lastDate;
+    $src = "<!-- aixada_js_src -->";
+    if ($useMenus) {
+        $src .= "
+            <script src=\"js/fgmenu/fg.menu.js?v={$aixada_vesion_lastDate}\"></script>
+            <script src=\"js/aixadautilities/jquery.aixadaMenu.js?v={$aixada_vesion_lastDate}\"></script>";
+    }
+    $src .= "
+        <script src=\"js/aixadautilities/jquery.aixadaXML2HTML.js?v={$aixada_vesion_lastDate}\"></script>
+        <script src=\"js/aixadautilities/jquery.aixadaUtilities.js?v={$aixada_vesion_lastDate}\"></script>";
+    if (get_config('use_ajaxQueue')) {
+        $src .= "
+            <script src=\"js/jquery-ajaxQueue/jQuery.ajaxQueue.js?v={$aixada_vesion_lastDate}\"></script>";
+    } else {
+        $src .= "
+            <script src=\"js/jquery-ajaxQueue/jQuery.ajaxQueueNo.js?v={$aixada_vesion_lastDate}\"></script>";
+    }
+    return $src . "\n";
+}
 
    try {
        $cookie = new Cookie();

--- a/php/inc/header.inc.php
+++ b/php/inc/header.inc.php
@@ -1,51 +1,10 @@
 <?php 
+require_once("php/inc/header.inc.base.php");
 
-define('DS', DIRECTORY_SEPARATOR);
-define('__ROOT__', dirname(dirname(dirname(__FILE__))).DS); 
-
-require_once("header.inc.version.php"); // To obtain: $aixada_vesion_lastDate
-require_once(__ROOT__ . 'php'.DS.'inc'.DS.'cookie.inc.php');
-require_once(__ROOT__ . 'local_config'.DS.'config.php');
-require_once(__ROOT__ . 'php'.DS.'utilities'.DS.'general.php');
-
-
-
-$default_theme = get_session_theme();
-//$dev = configuration_vars::get_instance()->development;
 $tpl_print_orders = configuration_vars::get_instance()->print_order_template;
 $tpl_print_myorders = configuration_vars::get_instance()->print_my_orders_template;
 $tpl_print_bill = configuration_vars::get_instance()->print_bill_template;
 $tpl_print_incidents = configuration_vars::get_instance()->print_incidents_template;
-
-
-require_once(__ROOT__ . 'local_config'.DS.'lang'.DS. get_session_language() . '.php');
-$language = get_session_language(); 
-
-// To declare common JavaScript sources used by a Aixada page.
-function aixada_js_version() {
-    global $aixada_vesion_lastDate;
-    return $aixada_vesion_lastDate;
-}
-function aixada_js_src($useMenus = true) {
-    global $aixada_vesion_lastDate;
-    $src = "<!-- aixada_js_src -->";
-    if ($useMenus) {
-        $src .= "
-            <script src=\"js/fgmenu/fg.menu.js?v={$aixada_vesion_lastDate}\"></script>
-            <script src=\"js/aixadautilities/jquery.aixadaMenu.js?v={$aixada_vesion_lastDate}\"></script>";
-    }
-    $src .= "
-        <script src=\"js/aixadautilities/jquery.aixadaXML2HTML.js?v={$aixada_vesion_lastDate}\"></script>
-        <script src=\"js/aixadautilities/jquery.aixadaUtilities.js?v={$aixada_vesion_lastDate}\"></script>";
-    if (get_config('use_ajaxQueue')) {
-        $src .= "
-            <script src=\"js/jquery-ajaxQueue/jQuery.ajaxQueue.js?v={$aixada_vesion_lastDate}\"></script>";
-    } else {
-        $src .= "
-            <script src=\"js/jquery-ajaxQueue/jQuery.ajaxQueueNo.js?v={$aixada_vesion_lastDate}\"></script>";
-    }
-    return $src . "\n";
-}
 
    try {
        $cookie = new Cookie();

--- a/php/inc/header.inc.version.php
+++ b/php/inc/header.inc.version.php
@@ -1,0 +1,7 @@
+<?php
+/* 
+ * The contents of this file are generated automatically. 
+ * Do not edit it, but instead run
+ * php make_canned_responses.php
+ */
+$aixada_vesion_lastDate = '20170304_234636';

--- a/report_account.php
+++ b/report_account.php
@@ -15,10 +15,7 @@
  
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
      
     <script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>
          

--- a/report_incidents.php
+++ b/report_incidents.php
@@ -12,10 +12,7 @@
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
    
 	<script type="text/javascript">
 	

--- a/report_sales.php
+++ b/report_sales.php
@@ -12,10 +12,7 @@
     
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
     <script type="text/javascript" src="js/tablesorter/jquery.tablesorter.js" ></script>
     
  	<script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>

--- a/report_shop_ufs.php
+++ b/report_shop_ufs.php
@@ -12,10 +12,7 @@
     
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
     <script type="text/javascript" src="js/aixadautilities/jquery.aixadaExport.js" ></script>
 
     <script type="text/javascript" src="js/tablesorter/jquery.tablesorter.js" ></script>

--- a/report_stats.php
+++ b/report_stats.php
@@ -16,10 +16,7 @@
 	
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
    
 	<script type="text/javascript">
 	$(function(){

--- a/report_stock.php
+++ b/report_stock.php
@@ -13,10 +13,7 @@
 	
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
    
 	<script type="text/javascript">
 	$(function(){

--- a/report_timelines.php
+++ b/report_timelines.php
@@ -13,10 +13,7 @@
 
    <script type="text/javascript" src="js/jquery/jquery.js"></script>
 		<script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-		<script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-		<script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-	   	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>   	
-	   	<script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+		<?php echo aixada_js_src(); ?>
 
 </head>
 

--- a/report_torn.php
+++ b/report_torn.php
@@ -15,10 +15,7 @@
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>  	
+    <?php echo aixada_js_src(); ?>	
    
 	<script type="text/javascript">
 	

--- a/shop_and_order.php
+++ b/shop_and_order.php
@@ -13,10 +13,7 @@
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
     <script type="text/javascript" src="js/aixadacart/jquery.aixadacart.js?v=20170108" ></script>
 
  	<script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>

--- a/shop_and_order.php
+++ b/shop_and_order.php
@@ -7,17 +7,17 @@
 
 	<link rel="stylesheet" type="text/css"   media="screen" href="css/aixada_main.css" />
   	<link rel="stylesheet" type="text/css"   media="print"  href="css/print.css" />
-  	<link rel="stylesheet" type="text/css"   media="screen" href="js/aixadacart/aixadacart.css?v=20170108" />
+  	<link rel="stylesheet" type="text/css"   media="screen" href="js/aixadacart/aixadacart.css?v=<?=aixada_js_version();?>" />
   	<link rel="stylesheet" type="text/css"   media="screen" href="js/fgmenu/fg.menu.css"   />
     <link rel="stylesheet" type="text/css"   media="screen" href="css/ui-themes/<?=$default_theme;?>/jqueryui.css"/>
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
     <?php echo aixada_js_src(); ?>
-    <script type="text/javascript" src="js/aixadacart/jquery.aixadacart.js?v=20170108" ></script>
+    <script type="text/javascript" src="js/aixadacart/jquery.aixadacart.js?v=<?=aixada_js_version();?>" ></script>
+ 	<script type="text/javascript" src="js/aixadacart/i18n/cart.locale-<?=$language;?>.js?v=<?=aixada_js_version();?>" ></script>
 
  	<script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>
- 	<script type="text/javascript" src="js/aixadacart/i18n/cart.locale-<?=$language;?>.js" ></script>
 
 
 	<script type="text/javascript">

--- a/torn.php
+++ b/torn.php
@@ -11,10 +11,7 @@
      
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>     	 
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
 	   
 	<script type="text/javascript">
 	$(function(){

--- a/validate.php
+++ b/validate.php
@@ -10,17 +10,17 @@
 
 
 	<link rel="stylesheet" type="text/css"   media="screen" href="css/aixada_main.css" />
-  	<link rel="stylesheet" type="text/css"   media="screen" href="js/aixadacart/aixadacart.css?v=20170108" />
+  	<link rel="stylesheet" type="text/css"   media="screen" href="js/aixadacart/aixadacart.css?v=<?=aixada_js_version();?>" />
   	<link rel="stylesheet" type="text/css"   media="screen" href="js/fgmenu/fg.menu.css"   />
     <link rel="stylesheet" type="text/css"   media="screen" href="css/ui-themes/<?=$default_theme;?>/jqueryui.css"/>
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
     <?php echo aixada_js_src(); ?>
-    <script type="text/javascript" src="js/aixadacart/jquery.aixadacart.js?v=20170108" ></script>
+    <script type="text/javascript" src="js/aixadacart/jquery.aixadacart.js?v=<?=aixada_js_version();?>" ></script>
+ 	<script type="text/javascript" src="js/aixadacart/i18n/cart.locale-<?=$language;?>.js?v=<?=aixada_js_version();?>" ></script>
 
     <script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>
- 	<script type="text/javascript" src="js/aixadacart/i18n/cart.locale-<?=$language;?>.js" ></script>
 
 
     <?php 

--- a/validate.php
+++ b/validate.php
@@ -16,10 +16,7 @@
 
     <script type="text/javascript" src="js/jquery/jquery.js"></script>
     <script type="text/javascript" src="js/jqueryui/jqueryui.js"></script>
-    <script type="text/javascript" src="js/fgmenu/fg.menu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaMenu.js"></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaXML2HTML.js" ></script>
-    <script type="text/javascript" src="js/aixadautilities/jquery.aixadaUtilities.js" ></script>
+    <?php echo aixada_js_src(); ?>
     <script type="text/javascript" src="js/aixadacart/jquery.aixadacart.js?v=20170108" ></script>
 
     <script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>


### PR DESCRIPTION
To work on hosting with few resources (memory) it is recommended to
sequence ajax requests, this avoids simulating requests from a page.

WHY?: We and other cooperative using the same hosting we have seen constant error appeared when loading the Aixada pages. Consulted with the technical service showed the log where says that not can allocate memory, and they recommended that we use a business-pro plan. Avoiding concurrent simultaneous ajax requests **the problem disappears completely**!

This patch also proposes:
  * Unify common js declarations on php by *aixada_js_src()*
  * Break js old cache generating *php/inc/header.inc.version.php* by *make_canned_responses.php* ad used in *aixada_js_src()* and *aixada_js_version()*
  * Separate the common part of *header.inc.php* into *header.inc.base.php* 