### PR TITLE
Depending on the SQL_MODE the installation may fail.

### DIFF
--- a/php/inc/memberuf.inc.php
+++ b/php/inc/memberuf.inc.php
@@ -67,7 +67,7 @@
 						</tr>
 						<tr>
 							<td><label for="last_seen"><?php echo $Text['last_logon']; ?>:</label></td>
-							<td colspan="2"><p class="textAlignLeft ui-corner-all">{last_successful_login}</p></td>
+							<td colspan="2"><p class="textAlignLeft ui-corner-all">{last_login_attempt}</p></td>
 						</tr>
 						<tr>
 							<td><label for="default_theme"><?php echo $Text['theme']; ?>:</label></td>

--- a/sql/aixada.sql
+++ b/sql/aixada.sql
@@ -1,3 +1,13 @@
+/** =============================
+ * WARNING: 
+ *      SESSION SQL_MODE will be altered to allow use of mySQL that does Aixada:
+ *              - for example `timestamp` with zero value.
+ ** =============================
+ */
+SET SESSION SQL_MODE = '';
+
+
+
 /***********************************************
  *	Aixada DB Structure 
  *
@@ -105,9 +115,9 @@ create table aixada_user (
   provider_id           int,
   language              char(5)        default 'en',
   gui_theme	       		varchar(50)    default null,
-  last_login_attempt    timestamp,
-  last_successful_login timestamp,
-  created_on            timestamp,
+  last_login_attempt    timestamp null,
+  last_successful_login timestamp null,
+  created_on            timestamp not null default current_timestamp,
   primary key (id),
   foreign key (uf_id) references aixada_uf(id),
   foreign key (member_id) references aixada_member(id),


### PR DESCRIPTION
It is proposed to force SQL_MODE in creation tables to avoid errors.

Also is proposed:
 * allow null in `last_login_attempt` and `last_successful_login` of `aixada_user`.
 * show `last_login_attempt` instead of `last_successful_login` since only `last_login_attempt` is updated.