### PR TITLE
Activate products: maintain the width and height of the cells on hover

### DIFF
--- a/css/aixada_main.css
+++ b/css/aixada_main.css
@@ -300,7 +300,11 @@ div#cashbox_listing				{width:100%; clear:both;}
 
 
 /** for de-activate products table **/
-.table_datesOrderableProducts td				{background:#EBEBEB; padding:5px;}
+.table_datesOrderableProducts td				{background:#EBEBEB; padding:4px;}
+.table_datesOrderableProducts td				{border:#EBEBEB 1px solid;}
+.table_datesOrderableProducts th				{border:#E1E1E1 1px solid;}
+.table_datesOrderableProducts .ax_state_hover   {border:1px solid #999999; pading:4px; color:red;}
+
 .table_datesOrderableProducts td.isOrderable	{background:#D1F3D1; cursor:pointer;}
 .table_datesOrderableProducts td.notOrderable	{background:#FFEDA1; cursor:pointer;}
 .table_datesOrderableProducts td.deactivated	{background:#FFCCCA;}

--- a/manage_orderable_products.php
+++ b/manage_orderable_products.php
@@ -14,7 +14,6 @@
 	<?php echo aixada_js_src(); ?>
  	<script type="text/javascript" src="js/jqueryui/i18n/jquery.ui.datepicker-<?=$language;?>.js" ></script>   
     
-   
 	<script type="text/javascript">
 	$(function(){
 		$.ajaxSetup({ cache: false });
@@ -244,11 +243,11 @@
 		//make the product name interactive for row actions menu
 		$('.rowActions')
 			.live('mouseenter', function(e){
-				$(this).addClass('ui-state-hover');
+				$(this).addClass('ax_state_hover');
 
 			})
 			.live('mouseleave', function(e){
-				$(this).removeClass('ui-state-hover');
+				$(this).removeClass('ax_state_hover');
 			})
 			.live('click',function(e){
 
@@ -310,12 +309,12 @@
 			.live('mouseenter', function(e){
 				$( "#colActionIcons" ).hide();
 				var colDate = $(this).attr('colDate');
-				$(".Date-"+colDate).addClass('ui-state-hover');
+				$(".Date-"+colDate).addClass('ax_state_hover');
 				
 			})
 			.live('mouseleave', function(e){
 				var colDate = $(this).attr('colDate');
-				$(".Date-"+colDate).removeClass('ui-state-hover');
+				$(".Date-"+colDate).removeClass('ax_state_hover');
 				e.stopPropagation();
 			})
 			.live('click', function(e){


### PR DESCRIPTION
The problem was that sometimes the emergent menus disappeared when activated, this was due to the cell size change produced by the 'mouseleave' event.

A color frame of 1px is proposed. It uses the background color and changes color on hover. It also prevents going the font from bold to normal. In this way the cells not change their size on hover.