### PR TITLE
Shop only with stock products

### DIFF
--- a/CHANGELOG-es.md
+++ b/CHANGELOG-es.md
@@ -32,7 +32,7 @@ Pasos para actualizar a la versión *2.8* desde *2.7* o un punto intermedio de *
 **Nuevas funcionalidades**
 * Importación productos usando platillas: permite crear los nuevos productos y en los existente actualizar precios y descripciones semanalmente cargando las hojas de calculo del proveedor. De forma opcional los producto que se han importado pueden quedar desactivados (:bulb:`config.php`: `$import_from_char_encoding`, `$import_templates[...]`)
 * Permite la personalización solo usando `config.php`: imagen inicial de login y en los informes el logo y los datos propios de la coope.   
-Ahora también se puede desactivar la compra directa, permitir validarse a uno mismo y no requerir depósitos (`$login_header_*`, `$coop_*`, `$validate_self`, `$validate_deposit`, `$use_shop`)
+Se puede desactivar la compra directa o solo permitir productos de stock, permitir validarse a uno mismo y no requerir depósitos (`$login_header_*`, `$coop_*`, `$validate_self`, `$validate_deposit`, `$use_shop`)
 * Nueva gestión del dinero que permite nuevas operaciones y anulaciones.
  En la misma pagina se muestran los cambios que se van haciendo,
  y entre ellos se puede ver el resultado resumido de la cooperativa.   
@@ -41,9 +41,12 @@ Ahora también se puede desactivar la compra directa, permitir validarse a uno m
  Se permite pequeños ajustes en la presentación de importes y fechas (:bulb:`config.php`: `$type_formats[...]`)
 
 **Mejoras y cambios**
-* Al hacer pedidos:
+* Al hacer pedidos y compras directas:
   * Se permite a las UF hacer pedidos de productos de stock (:bulb:`config.php`:
-    `$orders_allow_stock`, es de utilidad conjuntamente con `$use_shop=false`)
+    `$orders_allow_stock`)
+  * Se puede desactivar la compra directa con (:bulb:`config.php`:`$use_shop=false`)
+  * En la compra directa se pueden admitir todos los productos o solo los de stock
+    (:bulb:`config.php`:`$use_shop='only_stock'`, por defecto `'order_and_stock'`)
   * Las casillas de las cantidades se muestran en blanco en vez de a 0.
   * Cuando una cantidad se pone a 0 o en blanco se borra el producto de la cesta.
   * Se mejora la sincronización de cantidades con la cesta en las pestañas de
@@ -94,7 +97,7 @@ Ahora también se puede desactivar la compra directa, permitir validarse a uno m
     hostings (:bulb:`config.php`: `$email_safe_replyTo = true`) 
 * Mejoras en soporte de plataformas diversas, servidores Windows, MariaDB, versiones de PHP >= 5.3...
  (entre otros #184)
-  * Para trabajar en hostings con pocos recursos se recomientda sequenciar ajax
+  * Para trabajar en hostings con pocos recursos se recomienda secuenciar ajax
     (:bulb:`config.php`: `$use_ajaxQueue`).
 * La página report_stock muestra en valor total del stock de productos y adiciones/correcciones.
 * En la página proveedor/producto ahora se puede filtrar por descripción de los productos.

--- a/local_config/config.php.sample
+++ b/local_config/config.php.sample
@@ -57,12 +57,14 @@ class configuration_vars {
   ****************************************************************************/
 
   /**
-   *
-   * Indicates whether the store is used. If true (or missing), direct purchase
-   * options are shown, otherwise can only make orders.
-   * @var boolean
+   * Indicates whether the store is used. Possible values are:
+   *    - 'order_and_stock': The shop is shown with all active products
+   *                         (default if is missing or true)
+   *    - 'only_stock':      The shop is shown only with active stock products.
+   *    - false:             The shop is not shown.
+   * @var string|boolean
    */
-  public $use_shop = true;
+  public $use_shop = 'order_and_stock';
 
   /**
    * Allows allocate losses order distribution to a fictitious family (when the

--- a/php/ctrl/ShopAndOrder.php
+++ b/php/ctrl/ShopAndOrder.php
@@ -69,7 +69,7 @@ try{
 	    	exit;
 	
   		case 'getToShopProducts':
-	    	printXML(stored_query_XML_fields('get_products_detail',get_param('provider_id',0), get_param('category_id',0), get_param('like',''), 0, get_param('all',0), -1));
+	    	printXML(stored_query_XML_fields('get_products_detail',get_param('provider_id',0), get_param('category_id',0), get_param('like',''), '1234-01-01', get_param('all',0), -1));
 	    	exit;
 	    	
   		case 'getPreorderableProducts':

--- a/php/ctrl/ShopAndOrder.php
+++ b/php/ctrl/ShopAndOrder.php
@@ -32,7 +32,7 @@ try{
 	    	exit;
 	    
 	   	case 'getShopProviders':
-	    	printXML(stored_query_XML_fields('get_shop_providers'));
+	    	printXML(query_XML_fields(getSql_shop_providers()));
 	    	exit;
 	    	
 	    case 'getOrderCategories':
@@ -42,7 +42,7 @@ try{
 	    //retrieves all categories of all products active; optional the date parameter
 	    //would retrieve all categories for stock products and orderable for the given date. 	
 	    case 'getShopCategories':
-	    	printXML(stored_query_XML_fields('get_shop_categories_for_date', 0));
+	    	printXML(query_XML_fields(getSql_shop_categories()));
 	    	exit;
 	    	
 	    case 'getStockProviders':
@@ -69,7 +69,13 @@ try{
 	    	exit;
 	
   		case 'getToShopProducts':
-	    	printXML(stored_query_XML_fields('get_products_detail',get_param('provider_id',0), get_param('category_id',0), get_param('like',''), '1234-01-01', get_param('all',0), -1));
+            $use_shop = get_config('use_shop', 'order_and_stock');
+            printXML(stored_query_XML_fields('get_products_detail',
+                ($use_shop ? get_param('provider_id',0) : -1), // no products for shop
+                get_param('category_id',0), get_param('like',''),
+                ($use_shop === 'only_stock' ? '1234-01-01' : '0'), // '1234-01-01' is used to filter only stock products for shop
+                get_param('all',0), -1)
+            );
 	    	exit;
 	    	
   		case 'getPreorderableProducts':

--- a/php/inc/menu.inc.php
+++ b/php/inc/menu.inc.php
@@ -22,7 +22,7 @@
      } 
      echo '</select> ';
      
-     $cfg_use_shop = get_config('use_shop', true);
+     $cfg_use_shop = get_config('use_shop', 'order_and_stock');
      if (get_config('show_menu_language_select', false)) {
 	     echo '<select size="0" name="lang_select" id="lang_select">';
 	       $keys = $_SESSION['userdata']['language_keys'];

--- a/php/utilities/shop_and_order.php
+++ b/php/utilities/shop_and_order.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once(__ROOT__ . 'php/inc/database.php');
 require_once(__ROOT__ . 'local_config/config.php');
+require_once(__ROOT__ . 'php/inc/database.php');
+require_once(__ROOT__ . "php/utilities/general.php");
 
 function create_empty_cart($uf_id, $date_for_shop) {
     if (!$uf_id || !$date_for_shop) {
@@ -19,4 +20,40 @@ function create_empty_cart($uf_id, $date_for_shop) {
     return $db->last_insert_id();
 }
 
+function getSql_shop_providers() {
+    $sql = "select pv.id, pv.name
+        from aixada_provider pv
+	 	join aixada_product p on p.provider_id = pv.id
+        where
+            pv.active = 1
+            and p.active = 1";
+    $use_shop = get_config('use_shop', 'order_and_stock');
+    if ($use_shop === 'only_stock') {
+        $sql .= " and p.orderable_type_id in(1, 4)";
+    } elseif ($use_shop === false) {
+        $sql .= " and 1=0";
+    }
+    return $sql . "
+        group by pv.id, pv.name
+        order by pv.name";
+}
+
+function getSql_shop_categories() {
+    $sql = "select pc.id, pc.description
+        from aixada_product_category pc
+	 	join aixada_product p on p.category_id = pc.id
+        join aixada_provider pv on pv.id = p.provider_id
+        where
+            pv.active = 1
+            and p.active = 1";
+    $use_shop = get_config('use_shop', 'order_and_stock');
+    if ($use_shop === 'only_stock') {
+        $sql .= " and p.orderable_type_id in(1, 4)";
+    } elseif ($use_shop === false) {
+        $sql .= " and 1=0";
+    }
+    return $sql . "
+        group by pc.id, pc.description
+        order by pc.description";
+}
 ?>


### PR DESCRIPTION
This proposal expands the configuration possibilities for direct store.

Possible config values:
 - 'order_and_stock': The shop is shown with all active products
                      (default if is missing or true)
 - 'only_stock':      The shop is shown only with active stock products.
 - false:             The shop is not shown.

When uses 'only_stock' also the list of providers and the categories are reduced to cases where have active stock products.

See issue  #231
