### PR TITLE
CHANGELOG-es: Añadir cambios 2018 y agrupar por años

### DIFF
--- a/CHANGELOG-es.md
+++ b/CHANGELOG-es.md
@@ -1,122 +1,203 @@
-Changelog
-=========
+# Relación de cambios en Aixada
 
-v1.0
-----
-Hecho por Gilad Buzi en 2005
- 
+## ¿Cómo actualizar la versión?:
 
-v2.0
-----
-Re-lanzamiento: principales cambios en la estructura de base de datos y la interfaz que se basa ahora jQuey
+**¡La rama `marter` se considera estable!**  
+*(actualmente no se sigue un sistema de versiones desde la 2.7.0.1)*
 
-v2.5
-----
+Ver en wiki: [Actualización](https://github.com/jmueller17/Aixada/wiki/Actualizaci%C3%B3n)
 
-v2.6
-----
+***
 
-v2.7
-----
-Publicado 2 de abril 2013
+# Cambios año 2018
 
-v2.8 (a publicar en breve)
-----
-Pasos para actualizar a la versión *2.8* desde *2.7* o un punto intermedio de *master*:
- 1. Sobrescribir en el servidor todos los archivos (php, js, css, ...).
- 2. Ejecutar desde phpMyadmin:
-   * `sql/dbUpgradeTo2.8.sql` (el podrecimiento detecta el estado actual de BD y solo actualiza lo que falta)
-   * `sql/setup/aixada_queries_all.sql`. 
- 3. De forma optativa revisar los nuevos parámetros de configuración que puedan ser de utilidad.
+## Mejoras
 
-**Nuevas funcionalidades**
-* Importación productos usando platillas: permite crear los nuevos productos y en los existente actualizar precios y descripciones semanalmente cargando las hojas de calculo del proveedor. De forma opcional los producto que se han importado pueden quedar desactivados (:bulb:`config.php`: `$import_from_char_encoding`, `$import_templates[...]`)
-* Permite la personalización solo usando `config.php`: imagen inicial de login y en los informes el logo y los datos propios de la coope.   
-Se puede desactivar la compra directa o solo permitir productos de stock, permitir validarse a uno mismo y no requerir depósitos (`$login_header_*`, `$coop_*`, `$validate_self`, `$validate_deposit`, `$use_shop`)
-* Nueva gestión del dinero que permite nuevas operaciones y anulaciones.
- En la misma pagina se muestran los cambios que se van haciendo,
- y entre ellos se puede ver el resultado resumido de la cooperativa.   
- También se pueden usar cuentas de proveedores (factura y pagos) y ver sus saldos
- (:bulb:`config.php`: `$accounts[...]` *en particular* `$accounts['use_providers']`)   
- Se permite pequeños ajustes en la presentación de importes y fechas (:bulb:`config.php`: `$type_formats[...]`)
+### Hacer pedidos y compras
+  *  Solo permitir productos de stock en compras (:bulb:`config.php`:
+   `$use_shop='only_stock'`)
+  * Al hacer pedidos apare una lista de botones con las fechas activas (visión
+    alternativa al calendario).  
+    Si hay pedidos acumulativos activos el primer botón de fechas permite acceder
+    a ellos (se han eliminado las pestañas de acumulativos)
+  * Permitir los mismos filtros en pedidos acumulativos como para el resto
+    de pedos.
 
-**Mejoras y cambios**
-* Al hacer pedidos y compras directas:
-  * Se permite a las UF hacer pedidos de productos de stock (:bulb:`config.php`:
-    `$orders_allow_stock`)
-  * Se puede desactivar la compra directa con (:bulb:`config.php`:`$use_shop=false`)
-  * En la compra directa se pueden admitir todos los productos o solo los de stock
-    (:bulb:`config.php`:`$use_shop='only_stock'`, por defecto `'order_and_stock'`)
+### Gestión de pedidos
+  * Permitir activar un pedido acumulativo para todos los productos de un proveedor.
+    
+### Otras mejoras
+  * Instalación y actualización automática de Aixada vía `install.php`.
+
+    
+## Corrección de errores
+  * Se arreglas la cancelación de pedidos acumulativos.
+  * Para pedidos acumulativos se deja de mostrar los días restantes y en vez de
+    la fecha 1234-01-23 se informa que és un pedido acumulativo.
+  * #233 Arreglar que no se puedan cambiar productos de anotaciones si el pedido
+    está cerrado.
+  * #227 Al activar perdidos para una fecha evitar parpadeo y perder el foco del
+    menú desplegado.
+  * #229 Los informes de compras y pedidos por UF no funcionaban.
+
+***
+
+# Cambios año 2017
+
+## Mejoras
+
+### Hacer pedidos y compras
   * Las casillas de las cantidades se muestran en blanco en vez de a 0.
   * Cuando una cantidad se pone a 0 o en blanco se borra el producto de la cesta.
   * Se mejora la sincronización de cantidades con la cesta en las pestañas de
-    proveedor, categoría y buscar.
+  proveedor, categoría y buscar.
   * Se permite comentarios en los pedidos. Nuevo tipo de producto de comentarios
-    (sin precio) que al hacer un pedido requiere texto en vez de cantidades
-    (para enviar comentarios sobre los pedidos ya recibidos o para dar
-    instrucciones de preparación del pedido)
-* En gestión de pedidos:
-  * Se permite reabrir un pedido cerrado por error.
+  (sin precio) que al hacer un pedido requiere texto en vez de cantidades
+  (para enviar comentarios sobre los pedidos ya recibidos o para dar
+  instrucciones de preparación del pedido)
+
+### Gestión de pedidos
   * Se puede cancelar un pedido abierto sin enviarlo al proveedor.
   * Más formatos y mejoras de presentación para enviar o imprimir pedidos
-    (detallando: por productos+UF o UF+Productos) y se añade importe total.
+  (detallando: por productos+UF o UF+Productos) y se añade importe total.
   * Los pedidos se envían en el formato seleccionado para el proveedor y si no
-    según configuración (:bulb:`config.php`: `$email_order_format' y
-    `$email_order_prices`).
+  según configuración (:bulb:`config.php`: `$email_order_format' y
+  `$email_order_prices`).
   * Nueva opción para seleccionar el formato en que se desea imprimir los pedidos.
-* Al revisar pedidos:
+
+### Revisión de pedidos
+  * Permite añadir cantidades de cualquier producto del proveedor o UF activos,
+  ver nuevo botón "*Añadir ítem*"
+  (también se puede configurar para añadir al revisar la columna de una
+  determinada UF, y así por ejemplo asignar deterioros de reparto
+  :bulb:`config.php`: `$revision_fixed_uf`)
+
+### Otras mejoras
+  * Para trabajar en hostings con pocos recursos se recomienda secuenciar ajax
+  (:bulb:`config.php`: `$use_ajaxQueue`).
+
+***
+  
+# Cambios año 2016
+
+## Mejoras
+
+### Envío de correos
+  * Permitit el uso de servidores SMTP (:bulb:`config.php`: `$email_SMTP_host`).
+
+### Corrección de errores
+  * #205, #206 Al hacer pedidos se combrueva que el pedido no esté ya cerrado.
+  * #204 Usar precio final también en pedidos acumulativos.
+  * #202 Permitir catalogar más de 127 unidades.
+  * #201 Control el estado del pedido en el servidor para evitar peticiones
+    incoherentes.
+  * #200 Evitar errores por carros de compra vacios
+
+***
+  
+# Cambios año 2015
+
+## Nuevas funcionalidades
+  * Importación productos usando platillas: permite crear los nuevos productos y
+  en los existente actualizar precios y descripciones semanalmente cargando
+  las hojas de calculo del proveedor. De forma opcional los producto que se
+  han importado pueden quedar desactivados (:bulb:`config.php`:
+  `$import_from_char_encoding`, `$import_templates[...]`)
+  * Permite la personalización solo usando `config.php`: imagen inicial de login
+  y en los informes el logo y los datos propios de la coope.   
+  * Se puede desactivar la compra directa, permitir validarse a uno mismo y no
+  requerir depósitos (`$login_header_*`, `$coop_*`, `$validate_self`,
+  `$validate_deposit`, `$use_shop`)
+  * Nueva gestión del dinero que permite nuevas operaciones y anulaciones.  
+  En la misma pagina se muestran los cambios que se van haciendo,
+  y entre ellos se puede ver el resultado resumido de la cooperativa.   
+  También se pueden usar cuentas de proveedores (factura y pagos) y ver sus saldos
+  (:bulb:`config.php`: `$accounts[...]` *en particular* `$accounts['use_providers']`)   
+  Se permite pequeños ajustes en la presentación de importes y fechas
+  (:bulb:`config.php`: `$type_formats[...]`)
+
+## Mejoras
+
+### Hacer pedidos y compras
+  * Se permite a las UF hacer pedidos de productos de stock (:bulb:`config.php`:
+  `$orders_allow_stock`)
+  * Se puede desactivar la compra directa con (:bulb:`config.php`:`$use_shop=false`)
+
+### Gestión de pedidos
+  * Mejora de rendimiento al activar fechas de productos para pedidos (pruebas
+    satisfactorias con más de 500)
+  * Se permite reabrir un pedido cerrado por error.
+
+### Revisar pedidos
   * Permite cambiar precios y re-calcula el importe y así poder cuadrar el
-    importe del albarán con el importe calculado.
+  importe del albarán con el importe calculado.
   * Muestra el nombre de la UF al ponerse sobre una celda.
   * Puede configurarse en que orden aparecen las columna de las UF
-    (:bulb:`config.php`: `$order_review_uf_sequence`)
+  (:bulb:`config.php`: `$order_review_uf_sequence`)
   * Permite asignar productos cualquier casilla en blanco de una UF que
-    no haya pedido ese producto.
-  * Permite añadir cantidades de cualquier producto del proveedor o UF activos,
-    ver nuevo botón "*Añadir ítem*"
-    (también se puede configurar para añadir al revisar la columna de una
-    determinada UF, y así por ejemplo asignar deterioros de reparto
-    :bulb:`config.php`: `$revision_fixed_uf`)
+  no haya pedido ese producto.
   * Se puede distribuir y validar directamente un pedido (:bulb:`config.php`:
-    `$order_distribution_method`, `$order_distributeValidate_invoce`)
+  `$order_distribution_method`, `$order_distributeValidate_invoce`)
   * Al volver a revisar un pedido ya distribuido se permite conservar
-    el trabajo de revisión hecho previamente.
-* En validación de cestas:
+  el trabajo de revisión hecho previamente.
+
+### Validación de cestas
   * Es posible configurar que al validar muestre todos los carros de la semana
     (:bulb:`config.php`: `$validate_show_carts`).
   * Se pueden crear cestas vacías para asignar compra a UF sin pedido o compra
     previa (:bulb:`config.php`: `$validate_btn_create_carts`) 
   * Se solventa el problema de poner productos en cestas vacías.
-* Añadir edición de la mayoría de tablas auxiliares y mejorar la existente permitiendo edición en la lista.
-* Mejorar el envío de correos:  
-(envío de pedido al proveedor, re-establecimiento de contraseña y incidentes)
+
+### Envío de correos  
+(envío de pedido al proveedor, re-establecimiento de contraseña e incidentes)
+
   * Formateo html de los mensajes.
   * Soportar acentos y caracteres especiales como `ç`, `ñ` etc.
-  * Permitir el uso de servidores SMTP (:bulb:`config.php`: `$email_SMTP_host`).
-  * Permite evitar un uso de reply-to que generaba sospechas de SPAM en algunos
-    hostings (:bulb:`config.php`: `$email_safe_replyTo = true`) 
-* Mejoras en soporte de plataformas diversas, servidores Windows, MariaDB, versiones de PHP >= 5.3...
- (entre otros #184)
-  * Para trabajar en hostings con pocos recursos se recomienda secuenciar ajax
-    (:bulb:`config.php`: `$use_ajaxQueue`).
-* La página report_stock muestra en valor total del stock de productos y adiciones/correcciones.
-* En la página proveedor/producto ahora se puede filtrar por descripción de los productos.
-* Exportación rudimentaria de pedido a csv
-* Las revisiones de pedidos ahora no se borran de la tabla `aixada_order_to_shop`. Era necesario para realizar un seguimiento del total de recibido revisado y validado.
-* Símbolo de moneda está ahora en `config.php` y la descripción moneda en archivos lang.
-* Desde Aixada se pueden usar un método alternativo de copia de bases de datos; pero si el método convencional falla la copia se realiza con el otro método.   Se puede forzar que siempre se utilice el alternativo (:bulb:`config.php`: `$db_backup_method`)
-* #79 Evita que compren artículos con `current_stock = 0` (:bulb:`config.php`: `$prevent_out_of_stock_purchase`).
-* Poner un poco más de ayuda.
-* #193 Mejora de rendimiento al activar fechas de productos para pedidos (pruebas satisfactorias con más de 500)
 
-**Corrección de errores**
-* Formulario de edición del producto, cálculo y visualización de precio bruto.
-* #49 Proveedor: Si faltaba UF responsable no se mostraba.
-* #51 La contraseña ahora trabaja con la longitud total pero es compatible con versiones anteriores.
-* #52, #78 Arreglar desactivar productos.
-* #134, #151 Se ha arreglado el problema en algunas instalaciones de XML cortados.
-* #183 Arreglar caso en que no se ejecutaba auto salvar de carros de la compra.
-* #185 Evitar cache de GET usando hostings NGINX comentado en #156.
-* #195 En algunos hostings fallaba el envío de pedidos a proveedores.
-* #194 No de importaba el tipo de IVA.
+### Otras mejoras
+  * Mejoras en soporte de plataformas diversas, servidores Windows, MariaDB,
+    versiones de PHP >= 5.3...
+  * Añadir edición de la mayoría de tablas auxiliares y mejorar la existente
+    permitiendo edición en la lista.
+  * Desde Aixada se pueden usar un método alternativo de copia de bases de
+    datos; pero si el método convencional falla la copia se realiza con el
+    otro método.   
+    Se puede forzar que siempre se utilice el alternativo (:bulb:`config.php`:
+    `$db_backup_method`)
+  * Poner un poco más de ayuda.
+
+### Corrección de errores
+  * #195 En algunos hostins fallaba el envío de pedidos a proveedores.
+  * #194 No de importaba el tipo de IVA.
+  * #185 Evitar cache de GET usando hostins NGINX comentado en #156.
+  * #183 Arreglar caso en que no se ejecutaba auto salvar de carros de la compra.
+  * #184 Evitar advertencias usando PHP-5.3
+  * #134, #151 Se ha arreglado el problema en algunas instalaciones de XML cortados.
+
+***
+  
+# Cambios años anteriores
+
+### Para más detalles ver: [CHANGELOG.md (en inglés)](https://github.com/jmueller17/Aixada/blob/master/CHANGELOG.md)
+
+### Algunas mejoras
+  * La página report_stock muestra en valor total del stock de productos y
+    adiciones/correcciones.
+  * En la página proveedor/producto ahora se puede filtrar por descripción de los productos.
+  * Exportación rudimentaria de pedido a csv
+  * Las revisiones de pedidos ahora no se borran de la tabla `aixada_order_to_shop`.
+    Era necesario para realizar un seguimiento del total de recibido revisado
+    y validado.
+  * Símbolo de moneda está ahora en `config.php` y la descripción moneda en
+    archivos de idiomas.
+  * Evitar comprar o pedir artículos con current_stock = 0 (:bulb:`config.php`: 
+    `$prevent_out_of_stock_purchase`)
+
+### Algunas correcciones de errores
+  * Formulario de edición del producto, cálculo y visualización de precio bruto.
+  * #49 Proveedor: Si faltaba UF responsable no se mostraba.
+  * #51 La contraseña ahora trabaja con la longitud total pero es compatible con
+  versiones anteriores.
+  * #52, #78 Arreglar desactivar productos.
+  * #134, #151 Se ha arreglado el problema en algunas instalaciones de XML cortados.
 

--- a/CHANGELOG-es.md
+++ b/CHANGELOG-es.md
@@ -47,14 +47,14 @@ Ver en wiki: [Actualización](https://github.com/jmueller17/Aixada/wiki/Actualiz
 ## Mejoras
 
 ### Hacer pedidos y compras
+  * Se permite comentarios en los pedidos. Nuevo tipo de producto de comentarios
+    que en los pedidos requiere texto en vez de cantidades y no tiene precio.  
+    (puede servir para enviar comentarios sobre los pedidos ya recibidos o para
+    dar instrucciones de preparación del pedido al proveedor)
   * Las casillas de las cantidades se muestran en blanco en vez de a 0.
   * Cuando una cantidad se pone a 0 o en blanco se borra el producto de la cesta.
   * Se mejora la sincronización de cantidades con la cesta en las pestañas de
   proveedor, categoría y buscar.
-  * Se permite comentarios en los pedidos. Nuevo tipo de producto de comentarios
-  (sin precio) que al hacer un pedido requiere texto en vez de cantidades
-  (para enviar comentarios sobre los pedidos ya recibidos o para dar
-  instrucciones de preparación del pedido)
 
 ### Gestión de pedidos
   * Se puede cancelar un pedido abierto sin enviarlo al proveedor.
@@ -83,7 +83,7 @@ Ver en wiki: [Actualización](https://github.com/jmueller17/Aixada/wiki/Actualiz
 ## Mejoras
 
 ### Envío de correos
-  * Permitit el uso de servidores SMTP (:bulb:`config.php`: `$email_SMTP_host`).
+  * Permitit el uso de servidores SMTP (:bulb:`config.php`: `$email_SMTP_host`)
 
 ### Corrección de errores
   * #205, #206 Al hacer pedidos se combrueva que el pedido no esté ya cerrado.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,10 @@ Released 2 April 2013
 * #37 filter session variables for table manager fix
 * ...and otherss
 
-v2.8 (to publish soon)
+v2.8 (see `master` instead of a version)
 ----
 
-*This document is out of date for version 2.8, see "CHANGELOG-es.md"*
+*This document is out of date for version >= 2.8, see "[CHANGELOG-es.md](https://github.com/jmueller17/Aixada/blob/master/CHANGELOG-es.md)"*
 
 **New Features**
 

--- a/php/ctrl/InstallAixada.php
+++ b/php/ctrl/InstallAixada.php
@@ -56,7 +56,7 @@ try{
                     "SELECT table_name FROM information_schema.tables where table_schema=DATABASE() and table_name='aixada_price'"
                 );
                 if (!$isUpdatable) {
-                    throw new Exception("The version of Aixada is previous to 2.6.3!\n" .
+                    throw new Exception("The version of Aixada is previous to 2.7!\n" .
                         "It must be updated manually!!\n\n" .
                         "(see 'sql/dbUpgradeTo2.6.2.sql' and also previous versions)"
                     );


### PR DESCRIPTION
Al intentar documentar los últimos cambios me ha parecido más lógico separar los cambios por años (para poder hablar de un CHANGELOG), y así he procedido.

Luego he puesto los nuevos cambios del 2018.

También he suprimido la referencia a versiones ya que hace tiempo `master` es la fuente correcta para instalar Aixada.

También he actualizado la wiki referente al uso de `install.php`.

Trabajando en la wiki he visto alguna pagina que se podian borrar:
  * [Coopide](https://github.com/jmueller17/Aixada/wiki/Coopide)
  * [Menu-Eco](https://github.com/jmueller17/Aixada/wiki/Menu-Eco)
  * [New-App-Day](https://github.com/jmueller17/Aixada/wiki/New-App-Day)

**¿Hay problema en borrarlas?**

También se podría borrar:
  * `sql/dbUpgradeTo2.1.sql`
  * `php/ctrl/Install.php` (no se usa en ningún *.js, *.php ni Makefile)

¿no?