### PR TITLE
Fix error MySQL error Data too long in GROUP_CONCAT()

### DIFF
--- a/php/inc/database.php
+++ b/php/inc/database.php
@@ -71,6 +71,7 @@ class DBWrap {
         throw new InternalException('Unable to select charset utf8. Current character set: ' 
                                     . $mysqli->character_set_name());
     $this->mysqli->query("SET SESSION SQL_MODE = '';");
+    $this->mysqli->query("SET SESSION group_concat_max_len = 255;");
   }
   /**
    * The DBWrap class is implemented as a Singleton. Call this


### PR DESCRIPTION
After spending a lot of time, I happened to have the error reported in #228 in my test server, and this has allowed me to find the solution.