### PR TITLE
Allow to connect mySql to a different port.

### DIFF
--- a/local_config/config.php.sample
+++ b/local_config/config.php.sample
@@ -44,8 +44,7 @@ class configuration_vars {
   /**
    * Configure the database connection
    */
-  public $db_type = 'mysqli';
-  public $db_host = 'localhost';
+  public $db_host = 'localhost'; // To force a port: $db_host='myHost:9999'
   public $db_name = 'aixada';
   public $db_user = 'aixada';
   public $db_password = 'aixada';

--- a/php/inc/adminDatabase.php
+++ b/php/inc/adminDatabase.php
@@ -26,7 +26,12 @@ function backup_as_internal($output_folder, $backup_name) {
 
 function connect_by_mysqli($host, $db_name, $user, $pass)
 {
-    $db = new mysqli($host, $user, $pass, $db_name); 
+    $host_ = explode(":", $host);
+    if (count($host_) > 1) {
+        $db = new mysqli($host_[0], $user, $pass, $db_name, $host_[1]);
+    } else {
+        $db = new mysqli($host, $user, $pass, $db_name);
+    }
     if ($db->connect_errno) {
         ob_clean();
         throw new Exception(
@@ -65,7 +70,8 @@ function execute_sql_files($db, $sql_folder, $sqlFilesArray) {
  *  * compression in chunks: 
  *      http://stackoverflow.com/questions/6073397/how-do-you-create-a-gz-file-using-php
  */
-function backup_by_mysqli($output_folder, $backup_name, $host, $db_name, $user, $pass) { //,$tables = '*')
+function backup_by_mysqli($output_folder, $backup_name, $host, $db_name, $user, $pass)
+{
     $db = connect_by_mysqli($host, $db_name, $user, $pass);
     $tables = array();
     $result = $db->query('SHOW TABLES;');

--- a/php/inc/database.php
+++ b/php/inc/database.php
@@ -32,11 +32,6 @@ require_once(__ROOT__ . 'local_config'.DS.'lang'.DS. get_session_language() . '.
 class DBWrap {
   public $debug = true;
 
-  private $type;
-  private $host;
-  private $name;
-  private $user;
-  private $password;
   private $mysqli = false;
   private $key_info = array();
   private static $instance = false;
@@ -54,12 +49,16 @@ class DBWrap {
   private function __construct() 
   {
     $cv = configuration_vars::get_instance();
-    $this->type = $cv->db_type;
-    $this->host = $cv->db_host;
-    $this->db_name = $cv->db_name;
-    $this->user = $cv->db_user;
-    $this->password = $cv->db_password;
-    $this->mysqli = new mysqli($this->host, $this->user, $this->password, $this->db_name);
+    $host = $cv->db_host;
+    $db_name = $cv->db_name;
+    $user = $cv->db_user;
+    $password = $cv->db_password;
+    $host_ = explode(":", $host);
+    if (count($host_) > 1) {
+        $this->mysqli = new mysqli($host_[0], $user, $password, $db_name, $host_[1]);
+    } else {
+        $this->mysqli = new mysqli($host, $user, $password, $db_name);
+    }
     if (mysqli_connect_errno())
       throw new InternalException('Unable to connect to database. ' . mysqli_connect_error());
     if (!$this->mysqli->set_charset("utf8"))


### PR DESCRIPTION
It is proposed to allow configure `$db_host` using the syntax `$db_host='myHost:9999'` to indicate a different port from the default.

This is useful when developing, allows use different bd systems on the same host, each one in different ports.

NOTE: `$db_type` is removed from `config.php.sample` since it is not used.