### PR TITLE
Allow more time in bd processes

### DIFF
--- a/install.php
+++ b/install.php
@@ -47,14 +47,14 @@ require_once __ROOT__ . 'php/inc/authentication.inc.php';
             <div id="titlewrap">
                 <h1>Install or uptate Aixada database</h1>
             </div>
-            <h2 id="install_mode" style="color: blue;"></h2>
-            <p id="msg_link">Confirm to do procedure!</p>
+            <h2 id="install_mode_1" style="color: blue;"></h2>
+            <p id="install_mode_2" style="color: #999;"></p>
             <br/>
             <p>
                 <span class="loadAnim floatLeft hidden">
                     <img src="img/ajax-loader_fff.gif"/>
                 </span>
-                <button id="btn_install">Do install</button>
+                <button id="btn_install">Do "<span id="install_mode_bt">install</span>"</button>
             </p>
             <br/><br/>
             <p id="dbError" class="width-280"></p>
@@ -106,11 +106,15 @@ require_once __ROOT__ . 'php/inc/authentication.inc.php';
                 $('#btn_install').button("disable");
             },
             success: function(msg) {
-                $('#install_mode').text(msg).show();
+                var msgArr = (msg + '\n').split('\n');
+                $('#install_mode_bt').text(msgArr[0]).show();
+                $('#install_mode_1').text(msgArr[0]).show();
+                $('#install_mode_2').text(msgArr[1]).show();
                 $('#btn_install').button("enable");
             },
             error: function(XMLHttpRequest, textStatus, errorThrown) {
-                $('#install_mode').text('').hide();
+                $('#install_mode_1').text('').hide();
+                $('#install_mode_2').text('').hide();
                 $('#install_log')
                     .addClass('logMessage wrongEnding')
                     .text(XMLHttpRequest.responseText)

--- a/php/ctrl/Admin.php
+++ b/php/ctrl/Admin.php
@@ -10,6 +10,7 @@ require_once __ROOT__ . "php/utilities/general.php";
 try{
   validate_session(); // The user must be logged in.
 	
+  ini_set('max_execution_time', 300);
   switch (get_param('oper')) {
 	
 	  	case 'backupDatabase':

--- a/php/ctrl/InstallAixada.php
+++ b/php/ctrl/InstallAixada.php
@@ -13,30 +13,40 @@ require_once __ROOT__ . "php/inc/adminDatabase.php";
 require_once __ROOT__ . "php/utilities/general.php";
 
 $LOG_FOLDER = 'local_config/dbBkups/';
+$LOG_FILE = $LOG_FOLDER . 'InstallAixada.log';
 
+$results = '';
 try{
     switch (get_param('oper')) {
         case 'aixada_check':
-            logInstall('--> Check install');
+            logInstall("--> Check install\n", true);
             
-            $response = (CheckExistAndLogin() ? "Update Aixada" : "INSTALL: A new Aixada");
+            $response = 
+                (CheckExistAndLogin() ? "Update Aixada" : "INSTALL a new Aixada") . 
+                "\nLogfile: " . $LOG_FILE;
             logInstall("Is: '{$response}'");
             echo $response;
             exit;
         case 'aixada_update':
-            logInstall('--> Start install');
+            ini_set('max_execution_time', 300);
+            logInstall("--> Start install\n\n", true);
             
             $existAixada = CheckExistAndLogin();
             
             // Start info.
-            $results = 
-                ($existAixada ?
-                    'Aixada database update' :
-                    'Aixada database NEW INSTALL') .
-                    ' | Using PHP v' . PHP_VERSION . "\n" .
-                'MySQL: host="' . get_config('db_host') . 
+            $results .= logInstall( 
+                $existAixada ?
+                'Aixada database update' :
+                'Aixada database NEW INSTALL'
+            );
+            $mySqlVersion = get_row_query('SELECT @@version v;');
+            $results .= logInstall(
+                ' | Using PHP v' . PHP_VERSION . "\n" .
+                $mySqlVersion['v'] .
+                    ': host="' . get_config('db_host') . 
                     '" database="' . get_config('db_name') .
-                    '" user="' . get_config('db_user') . "\"\n";
+                    '" user="' . get_config('db_user') . "\"\n"
+            );
 
             // Do it.
             $db = connect_by_mysqli(     
@@ -48,55 +58,72 @@ try{
             if (!$existAixada) {
                 // Create tables
                 $mode = 'Create';
-                $results .= "\nCreate tables & insert initial data:";
-                $results .= execute_sql_files($db, 'sql/', array(
-                    'aixada.sql',
-                    'setup/aixada_insert_defaults.sql', 
-                    'setup/aixada_insert_default_user.sql'
-                ));
+                $results .= logInstall(
+                    "\nCreate tables & insert initial data:"
+                );
+                $results .= logInstall(
+                    execute_sql_files($db, 'sql/', array(
+                        'aixada.sql',
+                        'setup/aixada_insert_defaults.sql', 
+                        'setup/aixada_insert_default_user.sql'
+                    ))
+                );
             } else {
                 // Do it!
-                $results .= "\n\nDone by: '" . get_session_login() . "' at " . date('Y-m-d H:i:s') . "\n\n";
+                $results .= logInstall(
+                    "\nDone by: '" . get_session_login() . "' at " . date('Y-m-d H:i:s') . "\n"
+                );
                 
                 // Do a previous backup.
-                $results .= "\nA database backup has been created as:\n  "  .
-                    backup_as_internal($LOG_FOLDER, get_backup_name()) . "\n";
+                $results .= logInstall(
+                    "\nA database backup has been created as:\n  "
+                );
+                $results .= logInstall(
+                    backup_as_internal($LOG_FOLDER, get_backup_name()) . "\n"
+                );
                     
                 // Update tables.
                 $mode = 'Update';
-                $results .= "\nUpdate tables:";
-                $results .= execute_sql_files($db, 'sql/', array(
-                    'dbUpgradeTo2.8.sql'
-                ));
+                $results .= logInstall("\nUpdate tables:");
+                $results .= logInstall(
+                    execute_sql_files($db, 'sql/', array('dbUpgradeTo2.8.sql'))
+                );
             }
             
             // Crate or replace procedures.
-            $results .= "\n{$mode} database procedures:" .
+            $results .= logInstall("\n{$mode} database procedures:");
+            $results .= logInstall(
                 execute_sql_files($db, 'sql/', array(
-                'queries/aixada_queries_account.sql',
-                'queries/aixada_queries_dates.sql',
-                'queries/aixada_queries_useruf.sql',
-                'queries/aixada_queries_incidents.sql',
-                'queries/aixada_queries_order.sql',
-                'queries/aixada_queries_products.sql',
-                'queries/aixada_queries_providers.sql',
-                'queries/aixada_queries_cart.sql',
-                'queries/aixada_queries_report.sql',
-                'queries/aixada_queries_shop.sql',
-                'queries/aixada_queries_statistics.sql',
-                'queries/aixada_queries_validate.sql',
-                'queries/canned_queries.sql'
-            ));
+                    'queries/aixada_queries_account.sql',
+                    'queries/aixada_queries_dates.sql',
+                    'queries/aixada_queries_useruf.sql',
+                    'queries/aixada_queries_incidents.sql',
+                    'queries/aixada_queries_order.sql',
+                    'queries/aixada_queries_products.sql',
+                    'queries/aixada_queries_providers.sql',
+                    'queries/aixada_queries_cart.sql',
+                    'queries/aixada_queries_report.sql',
+                    'queries/aixada_queries_shop.sql',
+                    'queries/aixada_queries_statistics.sql',
+                    'queries/aixada_queries_validate.sql',
+                    'queries/canned_queries.sql'
+                ))
+            );
             
             // Inform the new username and password.
             if (!$existAixada) {
-                $results .= "\nLoging as: user=\"admin\" password=\"admin\"\n";
+                $results .= logInstall(
+                    "\nLoging as: user=\"admin\" password=\"admin\"\n"
+                );
             }
             
             // Finished correctly.
-            $results .= "\n** {$mode} database process has finished correctly **";
-            logInstall($results);
+            $results .= logInstall(
+                "\n** {$mode} database process has finished correctly **"
+            );
             echo $results;
+            
+            logInstall('--> Finished correctly!', true);
             exit;
         default:  
             throw new Exception("ctrlAdmin: oper={$_REQUEST['oper']} not supported");  
@@ -104,20 +131,24 @@ try{
     }
 } catch(Exception $e) {
     header('HTTP/1.0 401 Install error');
-    logInstall("ERROR:\n" . $e->getMessage());
-    die($e->getMessage());
+    logInstall("ERROR:\n" . $e->getMessage(), true);
+    die($results . "\n...aborted!\n\n" . $e->getMessage());
 }
 
-function logInstall($text) {
-    global $LOG_FOLDER;
+function logInstall($text, $showTime = false) {
+    global $LOG_FILE;
     try{
         file_put_contents(
-            __ROOT__ . $LOG_FOLDER . 'InstallAixada.log', 
+            __ROOT__ . $LOG_FILE, 
+            ( $showTime ? 
+            (
             "\n\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -" .
-            "\n- - - - - - - - - - " . date('Y-m-d H:i:s') . " - - - - - - - - - -\n" .
+            "\n- - - - - - - - - - " . date('Y-m-d H:i:s') . " - - - - - - - - - -\n") :
+            "" ) .
             $text,
             FILE_APPEND
         );
+        return $text;
     } catch(Exception $e) {
     }
 }


### PR DESCRIPTION
The backup and database update may require more time.

It is proposed to extend the time.

And in database update also is proposed write each step in the log file instead of at the end. So if process is interrupted can see in what step of the execution happened.

There are also cosmetic changes on the petition page `install.php`