### PR TITLE
After install Aixada no theme is set for Admin.

### DIFF
--- a/php/inc/authentication.inc.php
+++ b/php/inc/authentication.inc.php
@@ -132,6 +132,9 @@ class Authentication {
 		    $language = $row['language'];
 		    $roles = $this->_ask_roles($db, $user_id);
 		    $theme	= $row['gui_theme'];
+		    if (!$theme) {
+		        $theme = 'start';
+		    }
 		    $current_role = ( in_array('Consumer', $roles) ? 'Consumer' : (isset($roles[0]) ? $roles[0] : '' ) );
 		    
 	
@@ -143,4 +146,3 @@ class Authentication {
 	    
   }
 }
-?>


### PR DESCRIPTION
This causes that the theme requested is `''` and `css\ui-themes\\jqueryui.css` file is not found.

It is proposed to force `'start'` theme when there is no established theme.