### PR TITLE
BUG: Cumulative order of the UF is lost if after making a normal order.

### DIFF
--- a/php/lib/order_cart_manager.php
+++ b/php/lib/order_cart_manager.php
@@ -192,7 +192,7 @@ class order_cart_manager extends abstract_cart_manager {
     	$db = DBWrap::get_instance();
         
     	//only delete those order items which don't have an order_id yet. 
-    	$db->Execute("delete from aixada_order_item where uf_id=:1q and order_id is null and (date_for_order=:2q or date_for_order='1234-01-23')", $this->_uf_id, $this->_date);	
+    	$db->Execute("delete from aixada_order_item where uf_id=:1q and order_id is null and (date_for_order=:2q)", $this->_uf_id, $this->_date);	
     }
     
     


### PR DESCRIPTION
The error was introduced by me in #239

Since there are no longer two tabs on the shopping cart, one for the date and another for the cumulative ones, there is no more double information in oper=commit of the order of the date and the preoder=true. Currently cumulatives are also worked as of date.

I did not see this `or date_for_order='1234-01-23'` in this `DELETE`, I'm sorry.