### PR TITLE
Fix problem that does not change SQL_MODE = '' using MariaDB 10.3.13

### DIFF
--- a/php/inc/database.php
+++ b/php/inc/database.php
@@ -64,8 +64,9 @@ class DBWrap {
     if (!$this->mysqli->set_charset("utf8"))
         throw new InternalException('Unable to select charset utf8. Current character set: ' 
                                     . $mysqli->character_set_name());
-    $this->mysqli->query("SET SESSION SQL_MODE = '';");
-    $this->mysqli->query("SET SESSION group_concat_max_len = 255;");
+    $this->mysqli->query("SET @@SQL_MODE = ' ';"); // At least one blank space is required!
+                                                   // otherwise, it does not act in MariaDB 10.3.13
+    $this->mysqli->query("SET @@group_concat_max_len = 255;");
   }
   /**
    * The DBWrap class is implemented as a Singleton. Call this


### PR DESCRIPTION
The use of `SQL_MODE = ''` is essential for the use of dates in various procedures.

MariaDB 10.3.13 ignores statement `SET SESSION SQL_MODE = '';`, which has caused problems in different installations.

See: #251