### PR TITLE
Fix dockerfile and improve local environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,3 +36,5 @@ RUN DEBIAN_FRONTEND=noninteractive \
     /var/cache/* \
     /var/lib/apt/lists/* \
     /var/tmp/*
+
+RUN docker-php-ext-install mysqli && docker-php-ext-enable mysqli

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2.3'
+services:
+  mariadb:
+    image: 'bitnami/mariadb:10.3'
+    environment:
+      - MARIADB_ROOT_PASSWORD=bitnami
+    volumes:
+      - '~/data/aixada:/bitnami'
+  phpmyadmin:
+    image: 'bitnami/phpmyadmin:4'
+    ports:
+      - '8080:80'
+      - '443:443'
+    depends_on:
+      - mariadb
+  php:
+    build: .
+    ports:
+      - '80:80'
+    volumes:
+      - '.:/var/www/html'
+    depends_on:
+      - mariadb


### PR DESCRIPTION
- Fix some errors on docker, caused by `mysqli` missing.
- Move `Dockerfile` to the root level, for visibilty
- Add `docker-compose` file with `mariadb` and `phpmyadmin` for a completely dockerized local environment.

Fixes #267 