### PR TITLE
Php8 initial

### DIFF
--- a/php/inc/database.php
+++ b/php/inc/database.php
@@ -156,7 +156,6 @@ class DBWrap {
 	   $this->mysqli->query($safe_sql_string));
     if (!$rs) 
       $this->handle_execute_error($this->mysqli->errno, $this->mysqli->error, $safe_sql_string);
-    }
     $this->next_to_last_query_SQL = $this->last_query_SQL;
     $this->last_query_SQL = $safe_sql_string;
     return $rs;

--- a/php/lib/account_operations.php
+++ b/php/lib/account_operations.php
@@ -92,7 +92,7 @@ class account_operations {
                 where account_id between 2000 and 2999)");
         }
         if (count($sql) != 0) {
-            $sql2 = implode($sql, ' union ').
+            $sql2 = implode(' union ', $sql).
                                    " order by ts desc, id desc limit {$limit};";
             return $db->Execute($sql2);
         } else	{
@@ -105,7 +105,7 @@ class account_operations {
      * Retrieves list of accounts
      * @param boolean $all if set to true, list active and non-active accounts. when set to false, list only active UFs
      */
-    public function get_accounts_XML($all=0, $account_types) {
+    public function get_accounts_XML($all=0, $account_types='') {
         $filter = $this->get_account_types_filter($account_types);
         // start XML
         $strXML = '';

--- a/php/lib/account_operations.php
+++ b/php/lib/account_operations.php
@@ -266,7 +266,7 @@ class account_operations {
             ); 
         }
         return ( count($where_array) > 0 ? 
-                '( '.implode($where_array, ' or ').' )' : '1=0' );
+                '( '.implode(' or ', $where_array).' )' : '1=0' );
     }
     /**
      * There are five types: 

--- a/php/lib/import_products.php
+++ b/php/lib/import_products.php
@@ -22,7 +22,7 @@ class import_products extends abstract_import_manager {
 	 * @param int $provider_id requires the id of an existing provider to which products pertain
 	 * @throws Exception
 	 */
-	public function __construct($data_table, $map=null, $provider_id){
+	public function __construct($data_table, $map=null, $provider_id=null){
 
 		$db = DBWrap::get_instance();
 	    $rs = $db->Execute('select id from aixada_provider where id=:1q', $provider_id);

--- a/php/utilities/general.php
+++ b/php/utilities/general.php
@@ -1140,7 +1140,7 @@ function get_commissions()
 
 function clean_zeros($value)
 {
-  return ((strpos($value, '.') !== false) ?
+  return (isset($value) && (strpos($value, '.') !== false) ?
 	  rtrim(rtrim($value, '0'), '.') 
 	  : $value);
 }

--- a/php/utilities/useruf.php
+++ b/php/utilities/useruf.php
@@ -241,7 +241,7 @@ function createPassword($length=8) {
 	$i = 0;
 	$password = "";
 	while ($i <= $length) {
-		$password .= $chars{mt_rand(0,strlen($chars))};
+		$password .= $chars[mt_rand(0,strlen($chars))];
 		$i++;
 	}
 	return $password;


### PR DESCRIPTION
**Fix FATAL ERROR introduced in PR #289**

* Fix some deprecate syntax in PHP-8

Remaining problems in \php\external
  * swiftmailer-5.x (syntax $char{} )
  * ZendGdata-1.12.2 (seems like quite a few problems)
  * spreadsheet-reader (seems like quite a few problems)

Using PHP-8 (and it is thought that also PHP 7.4)
  * import/export does not work
  * sending messages not tested yet, it is thought that it will not work
