### PR TITLE
Docker fixes and upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,40 @@
 FROM php:7-apache
 
-# Enable the Apache Headers module:
+# Enable headers module
 RUN ln -s /etc/apache2/mods-available/headers.load \
   /etc/apache2/mods-enabled/headers.load
 
-# Enable the Apache Rewrite module:
+# Enable rewrite module
 RUN ln -s /etc/apache2/mods-available/rewrite.load \
   /etc/apache2/mods-enabled/rewrite.load
 
-# Install GD, Imagick and ImageMagick as image conversion options:
-RUN DEBIAN_FRONTEND=noninteractive \
-  apt-get update && apt-get install -y --no-install-recommends \
+# Install syste, build dependencies with apt
+RUN DEBINA_FRONTEND=noninteractive \
+  apt-get update \
+  && apt-get install -y --no-install-recommends \
     libpng-dev \
     libjpeg-dev \
     libmagickwand-dev \
-    imagemagick \
-  && pecl install \
-    imagick \
-  && docker-php-ext-enable \
-    imagick \
-  && docker-php-ext-configure \
-    gd --with-jpeg-dir=/usr/include/ \
-  && docker-php-ext-install \
-    gd \
-  # Uninstall obsolete packages:
-  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set php.ini-development as system php config
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+
+# Install php extensions
+RUN pear config-set php_ini $PHP_INI_DIR/php.ini
+RUN printf "\n" | pecl install imagick
+RUN docker-php-ext-enable imagick
+RUN docker-php-ext-configure gd --with-jpeg
+RUN docker-php-ext-install gd
+RUN docker-php-ext-enable gd
+RUN docker-php-ext-install mysqli
+RUN docker-php-ext-enable mysqli
+
+# Clean instalation traces
+RUN apt-get autoremove -y \
     libpng-dev \
     libjpeg-dev \
     libmagickwand-dev \
-  # Remove obsolete files:
   && apt-get clean \
   && rm -rf \
     /tmp/* \
@@ -36,5 +42,3 @@ RUN DEBIAN_FRONTEND=noninteractive \
     /var/cache/* \
     /var/lib/apt/lists/* \
     /var/tmp/*
-
-RUN docker-php-ext-install mysqli && docker-php-ext-enable mysqli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache
+FROM php:8.1-apache
 
 # Enable headers module
 RUN ln -s /etc/apache2/mods-available/headers.load \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,49 @@
-version: '2.3'
+version: '3.9'
+volumes:
+  aixadadb:
+networks:
+  aixada:
+    driver: bridge
 services:
   mariadb:
-    image: 'bitnami/mariadb:10.3'
-    environment:
-      - MARIADB_ROOT_PASSWORD=bitnami
+    image: 'bitnami/mariadb:10.6'
+    networks:
+      - aixada
+    ports:
+      - '3306:3306'
     volumes:
-      - '~/data/aixada:/bitnami'
+      - 'aixadadb:/bitnami/mariadb'
+    environment:
+      - ALLOW_EMPTY_PASSWORD=no
+      - MARIADB_DATABASE=aixada
+      - MARIADB_USER=aixada
+      - MARIADB_PASSWORD=aixada
+      - MARIADB_ROOT_PASSWORD=root
+      - MARIADB_CHARACTER_SET=utf8
+      - MARIADB_COLLATE=utf8_general_ci
   phpmyadmin:
-    image: 'bitnami/phpmyadmin:4'
+    image: 'bitnami/phpmyadmin:5'
+    depends_on:
+      - mariadb
+    networks:
+      - aixada
     ports:
       - '8080:80'
-      - '443:443'
-    depends_on:
-      - mariadb
+    links:
+      - 'mariadb:database'
+    environment:
+      - DATABASE_HOST=mariadb
+      - DATABASE_ALLOW_NO_PASSWORD=false
   php:
     build: .
-    ports:
-      - '80:80'
-    volumes:
-      - '.:/var/www/html'
     depends_on:
       - mariadb
+    networks:
+      - aixada
+    ports:
+      - '80:80'
+      - '443:443'
+    links:
+      - 'mariadb:database'
+    volumes:
+      - '.:/var/www/html'


### PR DESCRIPTION
Relacionat amb l'issue  [#299](https://github.com/jmueller17/Aixada/issues/299).

1. He augmentat la versió de php a la imàtge de Docker, de 7 a 8.1
2. He fet descansar la instal·lació de les extensions de php sobre els _helper scripts_ que la propia imàtge de docker oficial de php recomana utilitzar al seu [README](https://hub.docker.com/_/php/)
3. He fet alguns canvis a la configuració de l'arxiu `docker-compose.yml` 