### PR TITLE
Modificar enviament incidents

### DIFF
--- a/php/utilities/incidents.php
+++ b/php/utilities/incidents.php
@@ -42,7 +42,7 @@ function manage_incident($incident_id){
 		//otherwise email to individual active users. 
 		} else {
 			//get active members
-			$rs = do_stored_query('get_member_listing', 1); 
+			$rs = do_stored_query('get_member_listing', 0); 
 	    	$to = get_list_rs($rs, 'email');
 			
 		}


### PR DESCRIPTION
Bones,

Al crear un nou incident per defecte s'envia a tots els usuaris de la cooperativa, estiguin actius o no. 

$rs = do_stored_query('get_member_listing', 1);

per

$rs = do_stored_query('get_member_listing', 0);

Perquè la rutina que crea la llista d'usuaris get_members_listing si rep un valor 1 inclou els usuaris inactius.