### PR TITLE
Fix issue #303 to validate empty carts

### DIFF
--- a/js/aixadacart/jquery.aixadacart.js
+++ b/js/aixadacart/jquery.aixadacart.js
@@ -218,6 +218,8 @@
 					_self.data('aixadacart').unsavedItems = true; 
 				} else { //if it is not, create a new row
 					if (emptyRow) { // Don't add a empty row
+						// but allows validation, could be an empty cart
+						$('#btn_submit').button( "option", "disabled", false );
 						return itemObj;
 					}
 					_self.data('aixadacart').unsavedItems = true; 
@@ -485,6 +487,7 @@
                                 });
                                 $('#global_cart_id').val(lastCartId);
                                 $('#global_ts_last_saved').val(ts_last_saved);
+                                $('#btn_submit').button( "option", "disabled", false );
                             }
                         });
                     } else {

--- a/php/lib/validation_cart_manager.php
+++ b/php/lib/validation_cart_manager.php
@@ -37,6 +37,14 @@ class validation_cart_manager extends shop_cart_manager {
    */
  protected function _postprocessing($arrQuant, $arrProdId, $arrIva, $arrRevTax, $arrOrderItemId, $cart_id, $arrPreOrder, $arrPrice, $addNotes)
   {
+    // Here at postprocessing, the cart may not exist if it was empty
+    // See: `abstract_cart_manager::commit(...)` which calls `_delete_cart()` when cart is empty.
+    $cart = get_row_query('SELECT id FROM aixada_cart WHERE id =' . $cart_id);
+    if (!$cart){
+        // No cart, nothing to do!
+        return;
+    }
+    
     //do_stored_query('deduct_stock_and_pay', $cart_id);
     do_stored_query('validate_shop_cart', $cart_id, $this->_op_id, 'cart #', 1);
   }

--- a/php/utilities/orders.php
+++ b/php/utilities/orders.php
@@ -598,7 +598,7 @@ function directly_validate_order($order_id, $record_provider_invoice) {
         
         // Check date for shop non empty carts.
         $row_or = get_row_query(
-            "select provider_id, date_for_order 
+            "select provider_id, date_for_order, date_for_shop
             from aixada_order where id = {$order_id};");
         $date_for_shop = $row_or['date_for_order'];
         $provider_id = $row_or['provider_id'];
@@ -692,6 +692,19 @@ function directly_validate_order($order_id, $record_provider_invoice) {
             do_stored_query('validate_shop_cart', $cart_id, $operator_id, 
                     "order#{$order_id} {$date_for_shop} cart#", 0);
         }
+        // Delete all empty carts for 'date_for_shop' on table 'aixada_order'
+        $date_for_shop_table = $row_or['date_for_shop'];
+        error_log("delete c from aixada_cart c 
+            left join aixada_shop_item si on si.cart_id=c.id 
+            where si.cart_id is null 
+                and c.date_for_shop = '{$date_for_shop_table}';");
+        $db->Execute(
+            "delete c from aixada_cart c 
+            left join aixada_shop_item si on si.cart_id=c.id 
+            where si.cart_id is null 
+                and c.date_for_shop = '{$date_for_shop_table}';"
+        );
+        
         if ($record_provider_invoice) {
             // Add provider invoice
             $ao = new account_operations();


### PR DESCRIPTION
Fix issue #303

If a cart is empty it is not possible to validate, it remains in the UF and there is no way to remove.

It is proposed to activate the validation process, in fact `validation_cart_manager` suppresses a empty cart. Also in the other validation way `direct validate order()` of `utilities/orders.php` remove empty carts of date for shop. And on validation screen `validate.php`, now validate button is enabled for empty carts.