### PR TITLE
Sticky table headers

### DIFF
--- a/css/aixada_main.css
+++ b/css/aixada_main.css
@@ -73,6 +73,7 @@ option 				{padding:1px 5px;}
 	
 /** different table styles **/
 table.tblListingDefault				{width:100%;  border-collapse:collapse;}
+table.tblListingDefault thead tr th {position:sticky;top:0;}
 table.tblListingDefault th			{background:#f3f3f3; padding:4px 2px; text-align:left;}
 table.tblListingDefault th.textAlignRight { text-align: right; }
 table.tblListingDefault th.textAlignCenter { text-align: center; }
@@ -108,11 +109,12 @@ table.tblFormsSettings	td	{text-align:left; padding-right:10px; padding-left:4px
 table.tblFormsSettings 	td p {border:1px solid #f3f3f3; background:#fafafa; padding:4px; }
 table.tblFormsSettings 	td label 	{float:left;}
 
-
+/** top menu */
+.fg-menu-container {z-index:1000}
 
 /** common layout **/
 div#wrap			{width:92%; margin: 0 auto; background-color:#fff;}
-div#stagewrap		{background-color:#ff; min-width:900px;}
+div#stagewrap		{background-color:#fff; min-width:900px;}
 div#stagewrap.hidden {visibility: hidden;}
 div#topMenu			{}
 div#menuBgBar		{padding:5px; margin-bottom:10px;}
@@ -301,6 +303,7 @@ div#cashbox_listing				{width:100%; clear:both;}
 
 
 /** for de-activate products table **/
+.table_datesOrderableProducts thead tr th	{position:sticky;top:0}
 .table_datesOrderableProducts td				{background:#EBEBEB; padding:4px;}
 .table_datesOrderableProducts td				{border:#EBEBEB 1px solid;}
 .table_datesOrderableProducts th				{border:#E1E1E1 1px solid;}
@@ -331,8 +334,9 @@ h3#orderInfoDate			{font-size:1.5em;}
 .btn_right					{margin-right:-2em; margin-left:4px; float:right;}
 #btn_overview				{vertical-align:middle; margin-right:20px; margin-top:1em;}
 .btn_back					{vertical-align:middle; margin-right:20px; margin-top:1em;}
+.tblReviseOrder	thead tr th	{position:sticky;top:0}
 .tblReviseOrder	td			{background:#EBEBEB; padding:4px; margin:0px;}
-td.cellInfo	{font-size:0.6em; background:#ff; opacity:.8; margin:0px; padding:0px;}
+td.cellInfo	{font-size:0.6em; background:#fff; opacity:.8; margin:0px; padding:0px;}
 td.revised	{background:#D1F3D1;}
 td.toRevise	{background:#FFEDA1;}
 td.missing	{background:#FFCCCA;}
@@ -391,6 +395,7 @@ input 					{height:1.6em;}
 .product_list, .table_listing, .purchase_listing, .tblOverviewOrders, .table_listing_cashbox, .table_datesOrderableProducts, .table_overviewShop {width:100%;}
 .product_list_mng td, th			{padding:2px 5px;}
 .table_listing td					{text-align:right; padding:1px;}
+.product_list thead tr th	{position:sticky;top:0}
 .product_list td					{text-align:right; background:#EBEBEB; padding:5px 5px;}
 .purchase_listing td				{text-align:right; padding-right:5px;}
 .table_listing_cashbox td			{text-align:left; padding:2px;}


### PR DESCRIPTION
Implements sticky table headers css pattern from [css-tricks](https://css-tricks.com/position-sticky-and-table-headers/).

Sticky table headers allow to maintain columns context on tables with more rows than the screen viewport can show.