### PR TITLE
Remove ":" from the backup name and add seconds

### DIFF
--- a/php/inc/adminDatabase.php
+++ b/php/inc/adminDatabase.php
@@ -1,6 +1,6 @@
 <?php
 function get_backup_name() {
-    return get_config('db_name'). '.' . date('Y-m-d H:i');
+    return get_config('db_name'). '.' . date('Y-m-d His');
 }
 
 function backup_as_internal($output_folder, $backup_name) {


### PR DESCRIPTION
Los dos puntos en el nombre causaba que la copia no se almacenara en el servidor, aunque sí se podía descargar en `/manage_admin.php`