### PR TITLE
Bug fixes in the upgrade Aixada_torns (by PR #306)

### DIFF
--- a/ajuda.php
+++ b/ajuda.php
@@ -1,7 +1,5 @@
 <?php
     include "php/inc/header.inc.php";
-    define('DS', DIRECTORY_SEPARATOR);
-    define('__ROOT__', dirname(dirname(dirname(__FILE__))).DS);
     require_once(__ROOT__ . "local_config/config.php");
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/manage_calendar.php
+++ b/manage_calendar.php
@@ -142,9 +142,9 @@
         success: function(response){
             let html = '<table>'+
                 '<tr><th COLSPAN="2"><h1><?php echo $Text['crear_torn'];?></h1></th></tr>';
-            for(let i=0;i < <?php echo get_config('ufsxTorn');?>;i++){
+            for(let i=0;i < <?php echo get_config('ufsxTorn', 2);?>;i++){
                 html += '<tr>'+
-                    '<th><?echo $Text['uf_short'];?>:</th>'+
+                    '<th><?php echo $Text['uf_short'];?>:</th>'+
                     '<th><select id="uf'+i+'" name="ufTorn'+i+'">';
                     for(let x=0;x<response.length;x++){
                         html += '<option value="'+response[x].id+'" name="ufSeleccionada">'+response[x].nomSelect+'</option>';
@@ -195,7 +195,7 @@
  function crearTorn(){
 
     let ufsArray = [];
-    for(let i=0;i< <?echo get_config('ufsxTorn');?>;i++){
+    for(let i=0;i< <?php echo get_config('ufsxTorn', 2);?>;i++){
         ufsArray[i] = document.getElementById("uf"+i).value;
     }
 

--- a/php/ctrl/Calendar.php
+++ b/php/ctrl/Calendar.php
@@ -75,7 +75,7 @@
             {
                 if(ufsAnulada($row['id'])){
                     $ufId = $row['id'];
-                    if($uf>=get_config('ufsxTorn') && $ufId != $ultimaUf[0]){
+                    if($uf>=get_config('ufsxTorn', 2) && $ufId != $ultimaUf[0]){
                         $dataInici = date("Y-m-d",strtotime($dataInici."+ 1 week"));
                         $db->Execute('insert into aixada_torns (dataTorn,ufTorn) values (:1q,:2q)', $dataInici, $ufId);               
                         $uf=1;

--- a/php/lib/calendar_operations.php
+++ b/php/lib/calendar_operations.php
@@ -53,6 +53,7 @@ function comprovarTorn($data){
     $db = DBWrap::get_instance();
     $rs = $db ->Execute('select * from aixada_torns where dataTorn >=:1q order by dataTorn asc', $dataActual);
 
+    $mateixTorn = '1900-00-00';
     while($row = $rs->fetch_assoc()) 
 	    {    				
         $ufId = $row['ufTorn'];
@@ -123,9 +124,10 @@ function presentarUfs($idOriginal, $dataOriginal, $i){
  function ufAnulada ($uf){
 
     $resultat = true;
-    for( $contador = 0; $contador < count(get_config('ufAnulades')); $contador++ )
+    $ufAnulades = get_config('ufAnulades', array(1)); // second parameter is default value when is not defined in config.php
+    for( $contador = 0; $contador < count($ufAnulades); $contador++ )
     {        
-         if(get_config('ufAnulades')[$contador] == $uf) {
+         if($ufAnulades[$contador] == $uf) {
             $resultat = false;             
          }
     }


### PR DESCRIPTION
Bug fixes in the upgrade `aixada_torns` (by PR #306)

PHP warnings fided:
 - Notice: Constant DS already defined in `\ajuda.php` on line 3
 - Notice: Constant __ROOT__ already defined in `\ajuda.php` on line 4
 - Warning: count(): Parameter must be an array or an object that implements Countable in `\php\lib\calendar_operations.php` on line 126
 - Notice: Undefined variable: mateixTorn in `\php\lib\calendar_operations.php` on line 63

Uso de sintaxis no segura de `<?` en `manage_calendar.php` (algunas versiones de PHP ya no ejecutan la sentencia)

Especificar siempre el valor por defecto al usar get_config() si no se gestiona `null` como resultado