### PR TITLE
Añadir nueva tabla `aixada_torns` en la actualización.

### DIFF
--- a/sql/dbUpgradeTo2.8.sql
+++ b/sql/dbUpgradeTo2.8.sql
@@ -37,8 +37,11 @@ CREATE PROCEDURE dbUpdateUtil_removeRelatedFk(in the_table_name varchar(255)) BE
     end loop read_loop;
 END $$
 
-DROP PROCEDURE IF EXISTS dbUpdate_280_c03 $$
-CREATE PROCEDURE dbUpdate_280_c03() BEGIN
+/* =========================
+ * CREATE update procedure
+ * ========================= */
+DROP PROCEDURE IF EXISTS dbUpdate_280_c04 $$
+CREATE PROCEDURE dbUpdate_280_c04() BEGIN
 
 IF NOT EXISTS (
     SELECT * FROM information_schema.tables where table_schema=DATABASE() and table_name='aixada_version'
@@ -59,7 +62,7 @@ IF NOT EXISTS (
 END IF;
 
 insert into aixada_version (module_name, version) values (
-CONCAT('START dbUpdate_280_c03: ', SYSDATE()), '2.8'); 
+CONCAT('START dbUpdate_280_c04: ', SYSDATE()), '2.8'); 
 
 IF NOT EXISTS (
     SELECT * FROM information_schema.tables where table_schema=DATABASE() and table_name='aixada_stock_movement_type'
@@ -283,12 +286,37 @@ IF NOT EXISTS (
     '> ALTER TABLE aixada_order_to_shop add index (order_item_id)', '2.8.3');
 END IF;
 
+/* =========================
+ * v2.8.4
+ * ========================= */
+IF NOT EXISTS (
+    SELECT * FROM information_schema.tables where table_schema=DATABASE() and table_name='aixada_torns'
+) THEN
+
+    /**
+     * Types of stock movements such as stock corrected, loss, etc. 
+     */
+    create table aixada_torns (
+      id            int(11) not null auto_increment,
+      dataTorn      date    not null,
+      ufTorn        int(11) not null,
+      primary key (id)
+    ) engine=InnoDB default character set utf8 collate utf8_general_ci;
+    
+    insert into aixada_version (module_name, version) values (
+    '> CREATE table aixada_torns', '2.8.4');
+END IF;
+
+
+/* =========================
+ * Execute update procedure
+ * ========================= */
 insert into aixada_version (module_name, version) values (
-CONCAT('END dbUpdate_280_c03: ', SYSDATE()), '2.8'); 
+CONCAT('END dbUpdate_280_c04: ', SYSDATE()), '2.8'); 
 
 END $$
 
-CALL dbUpdate_280_c03() $$
+CALL dbUpdate_280_c04() $$
 
-DROP PROCEDURE IF EXISTS dbUpdate_280_c03 $$
+DROP PROCEDURE IF EXISTS dbUpdate_280_c04 $$
 DELIMITER ;


### PR DESCRIPTION
Contemplar la nueva tabla `aixada_torns` (creada por el PR #306 de @mamuts)
   en el `dbUpgradeTo2.8.sql` para que se cree si no existe.
   
Esto también hará que `/install.php` añada la tabla.